### PR TITLE
6.6: Fix context menu on package updates page, performance improvements, hiding FAB assets from "your library", new driver page with full driver list, start minimized....

### DIFF
--- a/WMT-GUI.ps1
+++ b/WMT-GUI.ps1
@@ -5364,11 +5364,20 @@ param($Item)
 
 # Shared guard for every Your Library population path (list view, search,
 # scan collector, toggle re-apply). Returns $true only when UE/Fab assets
-# are hidden AND the row is tagged as UE.
+# are hidden AND the row is tagged as UE. Reclassify Epic rows here as well
+# so older library caches are filtered without requiring a cache rebuild.
 if (-not $global:WmtHideUeAssets) { return $false }
 if (-not $Item) { return $false }
-if (-not $Item.PSObject.Properties["IsUe"]) { return $false }
-return [bool]$Item.IsUe
+$isUe = $false
+if ($Item.PSObject.Properties["IsUe"]) { $isUe = [bool]$Item.IsUe }
+if (-not $isUe -and ([string]$Item.Source).Trim() -match "(?i)^(epic|legendary)$") {
+    $title = [string]$Item.Name
+    $id = [string]$Item.Id
+    $isUe = ($id -match '(?i)^[A-Za-z0-9][A-Za-z0-9_-]{8,}V\d+$' -or
+        $id -match '(?i)(?:^|_)(?:5\.\d+)$' -or
+        $title -match '(?i)\b(plugin|materials?|vfx|assets?|environment|\benv\b|sample|pack|props?|textures?|shaders?|animations?|sounds?|characters?|icvfx|metahumans?|importer|dialogue\s+tree|production\s+test)\b')
+}
+return $isUe
 }
 
 function Get-WmtSavedUpdateAutoScanMinutes {

--- a/WMT-GUI.ps1
+++ b/WMT-GUI.ps1
@@ -34086,7 +34086,7 @@ try {
             $app = $match.Groups["app"].Value.Trim()
             $ver = if ($match.Groups["version"].Success) { $match.Groups["version"].Value.Trim() } else { "" }
             if ([string]::IsNullOrWhiteSpace($title)) { continue }
-            $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$')
+            $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$' -or $app -match '(?i)^[A-Za-z0-9][A-Za-z0-9_-]{8,}V\d+$' -or $app -match '(?i)(?:^|_)(?:5\.\d+)$' -or $title -match '(?i)\b(plugin|materials?|vfx|assets?|environment|\benv\b|sample|pack|props?|textures?|shaders?|animations?|sounds?|characters?|icvfx|metahumans?|importer|dialogue\s+tree|production\s+test)\b')
             if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
                 foreach ($ueMetaRoot in $ueMetaRoots) {
                     $ueMetaCandidate = Join-Path $ueMetaRoot "$app.json"
@@ -39817,7 +39817,7 @@ $script:InvokeWingetSearch = {
                                     if ([string]::IsNullOrWhiteSpace($title)) { continue }
                                     $app = $match.Groups["app"].Value.Trim()
                                     $ver = if ($match.Groups["version"].Success) { $match.Groups["version"].Value.Trim() } else { "" }
-                                    $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$')
+                                    $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$' -or $app -match '(?i)^[A-Za-z0-9][A-Za-z0-9_-]{8,}V\d+$' -or $app -match '(?i)(?:^|_)(?:5\.\d+)$' -or $title -match '(?i)\b(plugin|materials?|vfx|assets?|environment|\benv\b|sample|pack|props?|textures?|shaders?|animations?|sounds?|characters?|icvfx|metahumans?|importer|dialogue\s+tree|production\s+test)\b')
                                     if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
                                         foreach ($ueMetaRoot in $ueMetaRoots) {
                                             $ueMetaCandidate = Join-Path $ueMetaRoot "$app.json"
@@ -40351,7 +40351,7 @@ $script:InvokeWingetSearch = {
                             # assets.json namespace set and name patterns as fallbacks.
                             $legIsUe = $false
                             try { if ($game.PSObject.Properties["IsUe"]) { $legIsUe = [bool]$game.IsUe } } catch {}
-                            if (-not $legIsUe) { $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$') }
+                            if (-not $legIsUe) { $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$' -or $legId -match '(?i)^[A-Za-z0-9][A-Za-z0-9_-]{8,}V\d+$' -or $legId -match '(?i)(?:^|_)(?:5\.\d+)$' -or $title -match '(?i)\b(plugin|materials?|vfx|assets?|environment|\benv\b|sample|pack|props?|textures?|shaders?|animations?|sounds?|characters?|icvfx|metahumans?|importer|dialogue\s+tree|production\s+test)\b') }
                             if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
                                 foreach ($ueMetaRoot in $ueMetaRoots) {
                                     $ueMetaCandidate = Join-Path $ueMetaRoot "$legId.json"
@@ -43267,7 +43267,7 @@ $ps = New-WmtPooledPowerShell
                     # a text-parsed cache does not veto the other sources.
                     $legIsUe = $false
                     try { if ($game.PSObject.Properties["IsUe"]) { $legIsUe = [bool]$game.IsUe } } catch {}
-                    if (-not $legIsUe) { $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$') }
+                    if (-not $legIsUe) { $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$' -or $legId -match '(?i)^[A-Za-z0-9][A-Za-z0-9_-]{8,}V\d+$' -or $legId -match '(?i)(?:^|_)(?:5\.\d+)$' -or $title -match '(?i)\b(plugin|materials?|vfx|assets?|environment|\benv\b|sample|pack|props?|textures?|shaders?|animations?|sounds?|characters?|icvfx|metahumans?|importer|dialogue\s+tree|production\s+test)\b') }
                     if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
                         foreach ($ueMetaRoot in $ueMetaRoots) {
                             $ueMetaCandidate = Join-Path $ueMetaRoot "$legId.json"
@@ -45531,7 +45531,7 @@ try {
                                 if ([string]::IsNullOrWhiteSpace($title)) { continue }
                                 $app = $match.Groups["app"].Value.Trim()
                                 $ver = if ($match.Groups["version"].Success) { $match.Groups["version"].Value.Trim() } else { "" }
-                                $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$')
+                                $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$' -or $app -match '(?i)^[A-Za-z0-9][A-Za-z0-9_-]{8,}V\d+$' -or $app -match '(?i)(?:^|_)(?:5\.\d+)$' -or $title -match '(?i)\b(plugin|materials?|vfx|assets?|environment|\benv\b|sample|pack|props?|textures?|shaders?|animations?|sounds?|characters?|icvfx|metahumans?|importer|dialogue\s+tree|production\s+test)\b')
                                 if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
                                     foreach ($ueMetaRoot in $ueMetaRoots) {
                                         $ueMetaCandidate = Join-Path $ueMetaRoot "$app.json"

--- a/WMT-GUI.ps1
+++ b/WMT-GUI.ps1
@@ -4879,6 +4879,7 @@ try {
         ReduceRamInTray            = [bool](Get-WmtReduceRamInTray -Settings $Settings)
         DisableBackgroundJobs      = [bool](Get-WmtDisableBackgroundJobs -Settings $Settings)
         UpdateScansDisabled         = [bool](Get-WmtUpdateScansDisabled -Settings $Settings)
+        LaunchMinimized             = [bool]$Settings.LaunchMinimized
         HideLegendaryUeAssets       = [bool](Get-WmtHideLegendaryUeAssets -Settings $Settings)
         SavedUpdateAutoScanMinutes  = (ConvertTo-Int (Get-WmtSavedUpdateAutoScanMinutes -Settings $Settings) 0)
         LoadWinapp2                = [bool]$Settings.LoadWinapp2
@@ -4931,6 +4932,7 @@ $defaults = @{
     ReduceRamInTray            = $true
     DisableBackgroundJobs      = $false
     UpdateScansDisabled         = $false
+    LaunchMinimized             = $false
     HideLegendaryUeAssets      = $true
     SavedUpdateAutoScanMinutes = 0
     LoadWinapp2                = $false 
@@ -4983,6 +4985,7 @@ if (Test-Path $path) {
         if ($json.PSObject.Properties["ReduceRamInTray"]) { $defaults.ReduceRamInTray = [bool]$json.ReduceRamInTray }
         if ($json.PSObject.Properties["DisableBackgroundJobs"]) { $defaults.DisableBackgroundJobs = [bool]$json.DisableBackgroundJobs }
         if ($json.PSObject.Properties["UpdateScansDisabled"]) { $defaults.UpdateScansDisabled = [bool]$json.UpdateScansDisabled }
+        if ($json.PSObject.Properties["LaunchMinimized"]) { $defaults.LaunchMinimized = [bool]$json.LaunchMinimized }
         if ($json.PSObject.Properties["HideLegendaryUeAssets"]) { $defaults.HideLegendaryUeAssets = [bool]$json.HideLegendaryUeAssets }
         if ($json.PSObject.Properties["SavedUpdateAutoScanMinutes"]) {
             try { $defaults.SavedUpdateAutoScanMinutes = [int]$json.SavedUpdateAutoScanMinutes } catch { $defaults.SavedUpdateAutoScanMinutes = 0 }
@@ -26359,7 +26362,8 @@ powercfg /S SCHEME_CURRENT | Out-Null
                             <TextBlock Text="Windows Maintenance Tool v$AppVersion" FontSize="14" Foreground="{DynamicResource TextSecondary}" FontWeight="SemiBold"/>
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
-                            <Button Name="btnStartWithWindows" Content="Start with Windows" Style="{StaticResource ActionBtn}" Height="32" MinWidth="140" Margin="0,0,8,0" ToolTip="Launch WMT automatically when Windows starts"/>
+                            <Button Name="btnStartWithWindows" Content="Start with Windows: Off" Style="{StaticResource ActionBtn}" Height="32" MinWidth="170" Margin="0,0,8,0" ToolTip="WMT does not launch at logon (no startup task, or task state: Disabled). Click to set the state to On."/>
+                            <Button Name="btnLaunchMinimized" Content="Launch Minimized: Off" Style="{StaticResource ActionBtn}" Height="32" MinWidth="160" Margin="0,0,8,0" ToolTip="WMT starts with a visible window. Click to start hidden in the system tray instead."/>
                             <Button Name="btnDisableBgJobs" Content="Bg Jobs: On" Style="{StaticResource ActionBtn}" Height="32" MinWidth="130" Margin="0,0,8,0" ToolTip="Background auto-refresh ENABLED. My Device info and Tweaks states load automatically. Click to disable."/>
                             <Button Name="btnDisableUpdateScans" Content="Update Scans: On" Style="{StaticResource ActionBtn}" Height="32" MinWidth="150" Margin="0,0,8,0" ToolTip="Disable all automatic and tray-triggered update scans. Manual scans will still work. Click to toggle."/>
                             <Button Name="btnToggleTheme" Content="Toggle Theme" Style="{StaticResource ActionBtn}" Height="32" MinWidth="112" ToolTip="Switch between dark and light theme"/>
@@ -28335,6 +28339,7 @@ $btnSupportDiscord = Get-Ctrl "btnSupportDiscord"
 $btnSupportIssue = Get-Ctrl "btnSupportIssue"
 $btnToggleTheme = Get-Ctrl "btnToggleTheme"
 $btnStartWithWindows = Get-Ctrl "btnStartWithWindows"
+$btnLaunchMinimized = Get-Ctrl "btnLaunchMinimized"
 $btnNavDownloads = Get-Ctrl "btnNavDownloads"
 $btnDonateIos12 = Get-Ctrl "btnDonateIos12"
 $btnDonate = Get-Ctrl "btnDonate"
@@ -28421,6 +28426,11 @@ $tabButton.Add_Click({
             if ($lstWinget.Items.Count -eq 0 -and -not (Get-WmtUpdateScansDisabled)) {
                 $btnWingetScan.RaiseEvent((New-Object System.Windows.RoutedEventArgs([System.Windows.Controls.Button]::ClickEvent)))
             }
+        }
+        if ($s.Name -eq "btnTabSupport") {
+            # Re-check the real Task Scheduler state whenever the Support tab
+            # is shown so the Start with Windows button always reflects off/on.
+            try { Update-WmtStartWithWindowsButton } catch {}
         }
         if ($s.Name -eq "btnTabMyDevice") {
             Update-MyDeviceResponsiveLayout
@@ -29891,6 +29901,11 @@ $searchIndexDeferTimer.Add_Tick({
     Add-SearchIndexAction "Disable Update Scans" { Set-WmtUpdateScansDisabled -Enabled $true; Update-WmtUpdateScansButton; Write-GuiLog "Update scans disabled." } "btnTabSupport"
     Add-SearchIndexAction "Enable Update Scans"  { Set-WmtUpdateScansDisabled -Enabled $false; Update-WmtUpdateScansButton; Write-GuiLog "Update scans enabled."; try { if (-not (Get-WmtDisableBackgroundJobs)) { Start-WmtUpdateAutoScanTimer } } catch {} } "btnTabSupport"
     Add-SearchIndexEntry "btnStartWithWindows" "Start with Windows"              "btnTabSupport"
+    Add-SearchIndexAction "Enable Start with Windows"  { Set-WmtStartWithWindows -Enabled $true;  Update-WmtStartWithWindowsButton; Write-GuiLog "Start with Windows enabled." } "btnTabSupport"
+    Add-SearchIndexAction "Disable Start with Windows" { Set-WmtStartWithWindows -Enabled $false; Update-WmtStartWithWindowsButton; Write-GuiLog "Start with Windows disabled." } "btnTabSupport"
+    Add-SearchIndexEntry "btnLaunchMinimized" "Launch Minimized" "btnTabSupport"
+    Add-SearchIndexAction "Enable Launch Minimized"  { Set-WmtLaunchMinimized -Enabled $true;  Update-WmtLaunchMinimizedButton; Write-GuiLog "Launch Minimized enabled. WMT will start hidden in the system tray." } "btnTabSupport"
+    Add-SearchIndexAction "Disable Launch Minimized" { Set-WmtLaunchMinimized -Enabled $false; Update-WmtLaunchMinimizedButton; Write-GuiLog "Launch Minimized disabled. WMT will start with a visible window." } "btnTabSupport"
     Add-SearchIndexAction "Light Mode" { Set-WmtThemePreference -Theme "light" } "btnTabSupport"
     Add-SearchIndexAction "Dark Mode" { Set-WmtThemePreference -Theme "dark" }  "btnTabSupport"
 
@@ -41629,138 +41644,261 @@ $btnToggleTheme.Add_Click({
 $script:WmtStartupTaskName = "WindowsMaintenanceTool"
 
 function Get-WmtStartupCommand {
-# Build the command parts for Task Scheduler.
-# Returns a hashtable: @{ FilePath; Arguments }
-if ($script:WmtIsCompiledExe) {
-    $exePath = $script:WmtProcessPath
-    if ([string]::IsNullOrWhiteSpace($exePath) -or -not (Test-Path -LiteralPath $exePath -PathType Leaf)) { return $null }
-    return @{ FilePath = $exePath; Arguments = "" }
-}
-else {
+    # Build the command parts for Task Scheduler.
+    # Returns a hashtable: @{ FilePath; Arguments }
+    if ($script:WmtIsCompiledExe) {
+        $exePath = $script:WmtProcessPath
+        if ([string]::IsNullOrWhiteSpace($exePath) -or -not (Test-Path -LiteralPath $exePath -PathType Leaf)) {
+            return $null
+        }
+        return @{ FilePath = $exePath; Arguments = "" }
+    }
+
     $scriptPath = $script:WmtScriptPath
-    if ([string]::IsNullOrWhiteSpace($scriptPath) -or -not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) { return $null }
+    if ([string]::IsNullOrWhiteSpace($scriptPath) -or -not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+        return $null
+    }
+
     $psExe = "powershell.exe"
     try {
         $cmd = Get-Command powershell.exe -ErrorAction SilentlyContinue
         if ($cmd -and $cmd.Source) { $psExe = $cmd.Source }
     }
     catch {}
-    return @{ FilePath = $psExe; Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`"" }
+
+    return @{
+        FilePath  = $psExe
+        Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`""
+    }
 }
+
+function Get-WmtStartupTask {
+    try {
+        $service = New-WmtTaskSchedulerService
+        if (-not $service) { return $null }
+
+        $root = $service.GetFolder("\")
+        return $root.GetTask($script:WmtStartupTaskName)
+    }
+    catch {
+        return $null
+    }
 }
 
 function Test-WmtStartWithWindows {
-try {
-    $task = Get-ScheduledTask -TaskName $script:WmtStartupTaskName -ErrorAction SilentlyContinue
-    if ($task -and $task.State -ne "Disabled") { return $true }
-}
-catch {}
-return $false
-}
+    try {
+        $task = Get-WmtStartupTask
+        if (-not $task) { return $false }
 
-function Test-WmtStartupEntryValid {
-# Check if the existing scheduled task points to a file that still exists.
-try {
-    $task = Get-ScheduledTask -TaskName $script:WmtStartupTaskName -ErrorAction SilentlyContinue
-    if (-not $task) { return $false }
-    foreach ($action in @($task.Actions)) {
-        $filePath = [string]$action.Execute
-        if (-not [string]::IsNullOrWhiteSpace($filePath) -and (Test-Path -LiteralPath $filePath -PathType Leaf)) {
-            return $true
-        }
+        # Task.State: 1 = Disabled, 2 = Queued, 3 = Ready, 4 = Running.
+        return ([int]$task.State -ne 1 -and [bool]$task.Enabled)
     }
-    return $false
-}
-catch {}
-return $false
-}
-
-function Repair-WmtStartupEntry {
-# If the scheduled task exists but points to a moved/deleted file,
-# update it to the current WMT path. If the current path is also
-# invalid, remove the task entirely.
-try {
-    if (-not (Test-WmtStartWithWindows)) { return }
-    $isValid = Test-WmtStartupEntryValid
-    if ($isValid) { return }
-
-    # Entry is stale � try to repair with the current path.
-    $cmdParts = Get-WmtStartupCommand
-    if (-not $cmdParts -or [string]::IsNullOrWhiteSpace($cmdParts.FilePath)) {
-        # Can't build a valid command � remove the stale task.
-        Unregister-ScheduledTask -TaskName $script:WmtStartupTaskName -Confirm:$false -ErrorAction SilentlyContinue
-        Write-GuiLog "Start with Windows: removed stale task (file was moved or deleted)."
-        return
+    catch {
+        return $false
     }
-
-    # Recreate the task with the current path.
-    Set-WmtStartWithWindows -Enabled $true
-    Write-GuiLog "Start with Windows: updated task to current path."
-}
-catch {
-    Write-GuiLog "Failed to repair startup task: $($_.Exception.Message)"
-}
 }
 
 function Set-WmtStartWithWindows {
-param([bool]$Enabled)
-try {
-    if ($Enabled) {
-        $cmdParts = Get-WmtStartupCommand
-        if (-not $cmdParts -or [string]::IsNullOrWhiteSpace($cmdParts.FilePath)) {
-            Write-GuiLog "Start with Windows: could not determine WMT launch path."
-            return
+    param([Parameter(Mandatory = $true)][bool]$Enabled)
+
+    try {
+        $service = New-WmtTaskSchedulerService
+        if (-not $service) {
+            Write-GuiLog "Start with Windows: could not connect to Task Scheduler."
+            return $false
         }
 
-        # Remove existing task if it exists.
-        Unregister-ScheduledTask -TaskName $script:WmtStartupTaskName -Confirm:$false -ErrorAction SilentlyContinue
+        $root = $service.GetFolder("\")
+        $existing = $null
+        try { $existing = $root.GetTask($script:WmtStartupTaskName) } catch {}
 
-        # Build the scheduled task:
-        # - Trigger: At logon
-        # - Action: Run WMT (exe or powershell.exe -File script.ps1)
-        # - Settings: Run with highest privileges (skips UAC)
-        $action = New-ScheduledTaskAction -FilePath $cmdParts.FilePath -Argument $cmdParts.Arguments
-        $trigger = New-ScheduledTaskTrigger -AtLogOn
-        $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive
-        $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+        if (-not $Enabled) {
+            if ($existing) {
+                try {
+                    $existing.Enabled = $false
+                    Write-GuiLog "Start with Windows disabled."
+                    return $true
+                }
+                catch {
+                    Write-GuiLog "Start with Windows: failed to disable task: $($_.Exception.Message)"
+                    return $false
+                }
+            }
 
-        Register-ScheduledTask -TaskName $script:WmtStartupTaskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
-        Write-GuiLog "Start with Windows: enabled (Task Scheduler, no UAC prompt)."
+            Write-GuiLog "Start with Windows disabled (no startup task exists)."
+            return $true
+        }
+
+        $command = Get-WmtStartupCommand
+        if (-not $command) {
+            Write-GuiLog "Start with Windows: WMT launch file could not be located."
+            return $false
+        }
+
+        # Task Scheduler COM constants.
+        $TASK_TRIGGER_LOGON          = 9
+        $TASK_ACTION_EXEC            = 0
+        $TASK_CREATE_OR_UPDATE       = 6
+        $TASK_LOGON_INTERACTIVE_TOKEN = 3
+        $TASK_RUNLEVEL_HIGHEST       = 1
+
+        $definition = $service.NewTask(0)
+        $definition.RegistrationInfo.Description = "Starts Windows Maintenance Tool when the user logs on."
+        try { $definition.RegistrationInfo.Author = [Environment]::UserName } catch {}
+
+        $principal = $definition.Principal
+        $principal.UserId = "$env:USERDOMAIN\$env:USERNAME"
+        $principal.LogonType = $TASK_LOGON_INTERACTIVE_TOKEN
+        $principal.RunLevel = $TASK_RUNLEVEL_HIGHEST
+
+        $trigger = $definition.Triggers.Create($TASK_TRIGGER_LOGON)
+        try { $trigger.UserId = "$env:USERDOMAIN\$env:USERNAME" } catch {}
+        try { $trigger.Enabled = $true } catch {}
+
+        $action = $definition.Actions.Create($TASK_ACTION_EXEC)
+        $action.Path = [string]$command.FilePath
+        $action.Arguments = [string]$command.Arguments
+        try { $action.WorkingDirectory = Split-Path -Parent ([string]$command.FilePath) } catch {}
+
+        $settings = $definition.Settings
+        try { $settings.Enabled = $true } catch {}
+        try { $settings.StartWhenAvailable = $true } catch {}
+        try { $settings.DisallowStartIfOnBatteries = $false } catch {}
+        try { $settings.StopIfGoingOnBatteries = $false } catch {}
+        try { $settings.ExecutionTimeLimit = "PT0S" } catch {}
+
+        # RegisterTaskDefinition with INTERACTIVE_TOKEN keeps the task tied to
+        # the logged-on user while RunLevel=Highest removes the normal UAC prompt.
+        [void]$root.RegisterTaskDefinition(
+            $script:WmtStartupTaskName,
+            $definition,
+            $TASK_CREATE_OR_UPDATE,
+            $null,
+            $null,
+            $TASK_LOGON_INTERACTIVE_TOKEN,
+            $null
+        )
+
+        Write-GuiLog "Start with Windows enabled."
+        return $true
     }
-    else {
-        Unregister-ScheduledTask -TaskName $script:WmtStartupTaskName -Confirm:$false -ErrorAction SilentlyContinue
-        Write-GuiLog "Start with Windows: disabled."
+    catch {
+        Write-GuiLog "Start with Windows: failed to update Task Scheduler: $($_.Exception.Message)"
+        return $false
     }
 }
-catch {
-    Write-GuiLog "Failed to set Start with Windows: $($_.Exception.Message)"
-}
+
+function Test-WmtStartupEntryValid {
+    try {
+        $task = Get-WmtStartupTask
+        if (-not $task -or -not (Test-WmtStartWithWindows)) { return $false }
+
+        $command = Get-WmtStartupCommand
+        if (-not $command) { return $false }
+
+        $actions = @($task.Definition.Actions)
+        if ($actions.Count -lt 1) { return $false }
+
+        $action = $actions[0]
+        $pathMatches = ([string]$action.Path).Trim() -ieq ([string]$command.FilePath).Trim()
+        $argsMatches = ([string]$action.Arguments).Trim() -eq ([string]$command.Arguments).Trim()
+
+        if ($pathMatches -and $argsMatches) { return $true }
+
+        # The WMT executable/script was moved or updated. Rebuild the enabled
+        # task so the button remains truthful and the next logon uses the
+        # current launch path.
+        Set-WmtStartWithWindows -Enabled $true | Out-Null
+        return (Test-WmtStartWithWindows)
+    }
+    catch {
+        return $false
+    }
 }
 
 function Update-WmtStartWithWindowsButton {
-if (-not $btnStartWithWindows) { return }
-$isEnabled = Test-WmtStartWithWindows
-if ($isEnabled) {
-    $btnStartWithWindows.Content = "Stop Starting with Windows"
-    $btnStartWithWindows.Style = ($window.FindResource("AccentBtn") -as [System.Windows.Style])
-}
-else {
-    $btnStartWithWindows.Content = "Start with Windows"
-    $btnStartWithWindows.Style = ($window.FindResource("ActionBtn") -as [System.Windows.Style])
-}
+    $btn = Get-Ctrl "btnStartWithWindows"
+    if (-not $btn) { return }
+
+    $isEnabled = Test-WmtStartWithWindows
+    Update-WmtTweakToggle `
+        -Button $btn `
+        -IsOn $isEnabled `
+        -OnLabel "Start with Windows: On" `
+        -OffLabel "Start with Windows: Off" `
+        -Description "Launches WMT automatically when Windows logs in using Task Scheduler with highest privileges."
 }
 
 if ($btnStartWithWindows) {
-# On startup, repair the startup entry if the file was moved.
-Repair-WmtStartupEntry
+    # Repair the startup entry if the WMT file was moved or the command changed.
+    Test-WmtStartupEntryValid | Out-Null
 
-# Set initial button state.
-Update-WmtStartWithWindowsButton
+    Update-WmtStartWithWindowsButton
 
-$btnStartWithWindows.Add_Click({
+    $btnStartWithWindows.Add_Click({
+        $script:WmtTaskService = $null
         $isEnabled = Test-WmtStartWithWindows
-        Set-WmtStartWithWindows -Enabled (-not $isEnabled)
-        Update-WmtStartWithWindowsButton
+        if (Set-WmtStartWithWindows -Enabled (-not $isEnabled)) {
+            Update-WmtStartWithWindowsButton
+        }
+    })
+}
+
+# --- Launch Minimized ---
+# Persists the preference in WMT's settings.json. When enabled, WMT hides
+# itself to the system tray immediately after the first window render.
+function Get-WmtLaunchMinimized {
+    try {
+        $settings = Get-WmtSettings
+        return [bool]$settings.LaunchMinimized
+    }
+    catch {
+        return $false
+    }
+}
+
+function Set-WmtLaunchMinimized {
+    param([Parameter(Mandatory = $true)][bool]$Enabled)
+
+    try {
+        $settings = Get-WmtSettings
+        $settings.LaunchMinimized = $Enabled
+        Save-WmtSettings -Settings $settings
+        return $true
+    }
+    catch {
+        Write-GuiLog "Launch Minimized: failed to save setting: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Update-WmtLaunchMinimizedButton {
+    $btn = Get-Ctrl "btnLaunchMinimized"
+    if (-not $btn) { return }
+
+    $isEnabled = Get-WmtLaunchMinimized
+    Update-WmtTweakToggle `
+        -Button $btn `
+        -IsOn $isEnabled `
+        -OnLabel "Launch Minimized: On" `
+        -OffLabel "Launch Minimized: Off" `
+        -Description "When enabled, WMT starts hidden in the system tray instead of showing the main window."
+}
+
+if ($btnLaunchMinimized) {
+    Update-WmtLaunchMinimizedButton
+
+    $btnLaunchMinimized.Add_Click({
+        $currentlyEnabled = Get-WmtLaunchMinimized
+        if (Set-WmtLaunchMinimized -Enabled (-not $currentlyEnabled)) {
+            Update-WmtLaunchMinimizedButton
+            if ($currentlyEnabled) {
+                Write-GuiLog "Launch Minimized disabled. WMT will start with a visible window."
+            }
+            else {
+                Write-GuiLog "Launch Minimized enabled. WMT will start hidden in the system tray."
+            }
+        }
     })
 }
 
@@ -45210,6 +45348,22 @@ $preloadDeferTimer.Start()
 # (deferred to avoid competing with My Device page stats for system resources).
 Update-MyDeviceResponsiveLayout
 Update-TweaksResponsiveLayout
+
+# If Launch Minimized is enabled, hide the freshly rendered window in the
+# system tray. This runs after ContentRendered so WPF has a real window to hide.
+try {
+    if (Get-WmtLaunchMinimized) {
+        if (Initialize-WmtTrayIcon -Window $window) {
+            $script:WmtHiddenToTray = $true
+            $window.ShowInTaskbar = $false
+            $window.Hide()
+            Write-GuiLog "Launch Minimized is enabled. WMT started hidden in the system tray."
+        }
+    }
+}
+catch {
+    try { Write-GuiLog "Launch Minimized startup handling failed: $($_.Exception.Message)" } catch {}
+}
 }.GetNewClosure()
 [void]$window.Add_ContentRendered($onMainWindowContentRendered)
 

--- a/WMT-GUI.ps1
+++ b/WMT-GUI.ps1
@@ -9,7 +9,7 @@
 # ==========================================
 # 1. SETUP
 # ==========================================
-$AppVersion = "6.5"
+$AppVersion = "6.6"
 $ErrorActionPreference = "SilentlyContinue"
 $script:WmtDebug = [bool](Get-WmtSetting -Name "DebugMode" -Default $false -ErrorAction SilentlyContinue)
 # Preserve UTF-8 for web content, alt codes, and Unicode symbols.
@@ -2026,6 +2026,10 @@ $script:MyDeviceSectionJobs[$Name] = [pscustomobject]@{
 function Update-MyDeviceStats {
 param([switch]$ForceRefresh, [switch]$Preload)
 $script:MyDeviceStatsStarted = $true
+# Remember whether this load ran with background jobs disabled: the section
+# collector timer only starts when jobs are enabled, so a disabled-mode load
+# leaves "scanning is disabled" placeholders on screen (queue never drains).
+$script:MyDeviceStatsLastDisabled = [bool](Get-WmtDisableBackgroundJobs)
 $script:StatsStartedAt = Get-Date
 $script:MyDeviceStatsPreloadMode = [bool]$Preload
 $script:MyDeviceStatsMaxConcurrent = 4
@@ -4186,6 +4190,7 @@ try {
         ReduceRamInTray            = [bool](Get-WmtReduceRamInTray -Settings $Settings)
         DisableBackgroundJobs      = [bool](Get-WmtDisableBackgroundJobs -Settings $Settings)
         UpdateScansDisabled         = [bool](Get-WmtUpdateScansDisabled -Settings $Settings)
+        HideLegendaryUeAssets       = [bool](Get-WmtHideLegendaryUeAssets -Settings $Settings)
         SavedUpdateAutoScanMinutes  = (ConvertTo-Int (Get-WmtSavedUpdateAutoScanMinutes -Settings $Settings) 0)
         LoadWinapp2                = [bool]$Settings.LoadWinapp2
         LoadWinapp3                = [bool]$Settings.LoadWinapp3
@@ -4237,6 +4242,7 @@ $defaults = @{
     ReduceRamInTray            = $true
     DisableBackgroundJobs      = $false
     UpdateScansDisabled         = $false
+    HideLegendaryUeAssets      = $true
     SavedUpdateAutoScanMinutes = 0
     LoadWinapp2                = $false 
     LoadWinapp3                = $false
@@ -4288,6 +4294,7 @@ if (Test-Path $path) {
         if ($json.PSObject.Properties["ReduceRamInTray"]) { $defaults.ReduceRamInTray = [bool]$json.ReduceRamInTray }
         if ($json.PSObject.Properties["DisableBackgroundJobs"]) { $defaults.DisableBackgroundJobs = [bool]$json.DisableBackgroundJobs }
         if ($json.PSObject.Properties["UpdateScansDisabled"]) { $defaults.UpdateScansDisabled = [bool]$json.UpdateScansDisabled }
+        if ($json.PSObject.Properties["HideLegendaryUeAssets"]) { $defaults.HideLegendaryUeAssets = [bool]$json.HideLegendaryUeAssets }
         if ($json.PSObject.Properties["SavedUpdateAutoScanMinutes"]) {
             try { $defaults.SavedUpdateAutoScanMinutes = [int]$json.SavedUpdateAutoScanMinutes } catch { $defaults.SavedUpdateAutoScanMinutes = 0 }
             if ($defaults.SavedUpdateAutoScanMinutes -lt 0) { $defaults.SavedUpdateAutoScanMinutes = 0 }
@@ -4638,6 +4645,55 @@ try {
 catch {}
 
 return $false
+}
+
+function Get-WmtHideLegendaryUeAssets {
+param($Settings)
+
+if (-not $Settings) { $Settings = Get-WmtSettings }
+
+try {
+    if ($Settings -is [System.Collections.IDictionary] -and $Settings.Contains("HideLegendaryUeAssets")) {
+        return [bool]$Settings["HideLegendaryUeAssets"]
+    }
+    if ($Settings.PSObject.Properties["HideLegendaryUeAssets"]) {
+        return [bool]$Settings.HideLegendaryUeAssets
+    }
+}
+catch {}
+
+return $true
+}
+
+# --- Unreal Engine / Fab asset visibility (Your Library) ---
+# One live flag shared by every handler context: plain scriptblock handlers,
+# GetNewClosure handlers (library search debounce) and functions called from
+# them all resolve $global: the same way, so the filter never depends on
+# which scope a population path runs in.
+try { $global:WmtHideUeAssets = [bool](Get-WmtHideLegendaryUeAssets) } catch { $global:WmtHideUeAssets = $true }
+
+function Set-WmtFabAssetsButtonLabel {
+    if (-not $btnToggleFabAssets) { return }
+    $label = "Fab Assets: " + $(if ($global:WmtHideUeAssets) { "Hidden" } else { "Shown" })
+    if ($btnToggleFabAssets.Content -is [System.Windows.Controls.StackPanel]) {
+        foreach ($child in @($btnToggleFabAssets.Content.Children)) {
+            if ($child -is [System.Windows.Controls.TextBlock]) { $child.Text = $label }
+        }
+    }
+    else { $btnToggleFabAssets.Content = $label }
+}
+try { Set-WmtFabAssetsButtonLabel } catch {}
+
+function Test-WmtFabAssetHidden {
+param($Item)
+
+# Shared guard for every Your Library population path (list view, search,
+# scan collector, toggle re-apply). Returns $true only when UE/Fab assets
+# are hidden AND the row is tagged as UE.
+if (-not $global:WmtHideUeAssets) { return $false }
+if (-not $Item) { return $false }
+if (-not $Item.PSObject.Properties["IsUe"]) { return $false }
+return [bool]$Item.IsUe
 }
 
 function Get-WmtSavedUpdateAutoScanMinutes {
@@ -24191,7 +24247,7 @@ powercfg /S SCHEME_CURRENT | Out-Null
                 <!-- Library List (initially hidden) -->
                 <Border Name="brdLibraryList" Grid.Row="2" Style="{StaticResource CardStyle}" Padding="0" Visibility="Collapsed">
                     <DockPanel>
-                        <Border DockPanel.Dock="Top" Style="{StaticResource ModernSearchBoxStyle}" Margin="8,8,8,0">
+                        <Border DockPanel.Dock="Top" Style="{StaticResource ModernSearchBoxStyle}" Margin="8,8,8,8">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
@@ -24258,6 +24314,7 @@ powercfg /S SCHEME_CURRENT | Out-Null
                         <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left">
                             <Button Name="btnBackToCatalog" Content="Back to Catalog" Style="{StaticResource ActionBtn}" ToolTip="Return to the software catalog" Visibility="Collapsed"/>
                             <Button Name="btnLibraryRefresh" Content="Refresh Library" Style="{StaticResource ActionBtn}" ToolTip="Re-scan Steam manifests and refresh Legendary/GOGDL caches" Visibility="Collapsed"/>
+                            <Button Name="btnToggleFabAssets" Content="Fab Assets: Hidden" Style="{StaticResource ActionBtn}" ToolTip="Show or hide Unreal Engine / Fab marketplace assets in Your Library. They are still scanned for updates either way." Visibility="Collapsed"/>
                             <TextBlock Name="lblLibraryStatus" Text="" VerticalAlignment="Center" Foreground="{DynamicResource TextSecondary}" FontStyle="Italic" Margin="12,0,0,0"/>
                         </StackPanel>
                         <!-- Catalog actions (always visible) -->
@@ -26111,6 +26168,8 @@ $iconDeferTimer.Add_Tick({
     Set-ButtonIcon "btnBackToUpdates" "M20,11H7.83L13.42,5.41L12,4L4,12L12,20L13.41,18.59L7.83,13H20V11Z" "Back to Updates" "Return to the package updates view" 16
     Set-ButtonIcon "btnBackToCatalog" "M20,11H7.83L13.42,5.41L12,4L4,12L12,20L13.41,18.59L7.83,13H20V11Z" "Back to Catalog" "Return to the software catalog" 16
     Set-ButtonIcon "btnLibraryRefresh" "M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z" "Refresh Library" "Re-scan Steam manifests and refresh Legendary/GOGDL caches" 16
+    Set-ButtonIcon "btnToggleFabAssets" "M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z" "Fab Assets: Hidden" "Show or hide Unreal Engine / Fab marketplace assets in Your Library. They are still scanned for updates either way." 16
+    try { Set-WmtFabAssetsButtonLabel } catch {}
     $iconDeferTimer = $null
 })
 $iconDeferTimer.Start()
@@ -26614,10 +26673,6 @@ try {
     if ($script:TweakButtonStatesCache -and $script:TweakButtonStatesCache.Count -gt 0) {
         $regCache = $script:TweakButtonStatesCache
     }
-    $pathCheckCache = @{}
-    if ($script:TweakButtonStatesPathChecks -and $script:TweakButtonStatesPathChecks.Count -gt 0) {
-        $pathCheckCache = $script:TweakButtonStatesPathChecks
-    }
 
     # Load pre-fetched non-registry data (services, fsutil, powercfg, etc.)
     # so the UI thread makes ZERO blocking calls — everything is cached.
@@ -26645,15 +26700,6 @@ try {
         $item = $regCache[$Path]
         if ($item -and $item.PSObject.Properties[$Name]) { return $item.$Name }
         return $Default
-    }.GetNewClosure()
-
-    $getPathExists = {
-        param([string]$Path)
-        if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
-        if ($pathCheckCache.ContainsKey($Path)) { return $pathCheckCache[$Path] }
-        $exists = Get-WmtTweakPathExistsCached -Path $Path -Default $false
-        $pathCheckCache[$Path] = $exists
-        return $exists
     }.GetNewClosure()
 
     $setButtonEnabled = {
@@ -26747,12 +26793,12 @@ try {
     $classicContext = Get-WmtRegistryPathExists "HKCU:\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32"
     $btnToggleCtxMenu = Get-Ctrl "btnToggleCtxMenu"
     Update-WmtTweakToggle $btnToggleCtxMenu $classicContext "Classic Right-Click" "Modern Right-Click"
-    $takeOwnInstalled = Get-WmtRegistryPathExists "HKCU:\Software\Classes\Directory\shell\WMT_TakeOwnership"
+    $takeOwnInstalled = Get-WmtRegistryPathExists "HKCR:\Directory\shell\WMT_TakeOwnership"
     $btnToggleTakeOwnership = Get-Ctrl "btnToggleTakeOwnership"
-    Update-WmtTweakToggle $btnToggleTakeOwnership $takeOwnInstalled "Add Take Ownership" "Remove Take Ownership"
-    $psHereInstalled = Get-WmtRegistryPathExists "HKCU:\Software\Classes\Directory\Background\shell\WMT_OpenPowerShell"
+    Update-WmtTweakToggle $btnToggleTakeOwnership $takeOwnInstalled "Remove Take Ownership" "Add Take Ownership"
+    $psHereInstalled = Get-WmtRegistryPathExists "HKCR:\Directory\Background\shell\WMT_OpenPowerShell"
     $btnTogglePsHere = Get-Ctrl "btnTogglePsHere"
-    Update-WmtTweakToggle $btnTogglePsHere $psHereInstalled "Add PowerShell Here" "Remove PowerShell Here"
+    Update-WmtTweakToggle $btnTogglePsHere $psHereInstalled "Remove PowerShell Here" "Add PowerShell Here"
 
     # --- NEW TOGGLE STATE DETECTION ---
     $polAI = "HKCU:\Software\Policies\Microsoft\Windows\WindowsAI"
@@ -27529,6 +27575,7 @@ $lstCatalog = Get-Ctrl "lstCatalog"
 $lstLibrary = Get-Ctrl "lstLibrary"
 $txtLibrarySearch = Get-Ctrl "txtLibrarySearch"
 $btnLibraryClearSearch = Get-Ctrl "btnLibraryClearSearch"
+$btnToggleFabAssets = Get-Ctrl "btnToggleFabAssets"
 $brdCatalogList = Get-Ctrl "brdCatalogList"
 $brdLibraryList = Get-Ctrl "brdLibraryList"
 $pnlCatalogActions = Get-Ctrl "pnlCatalogActions"
@@ -27618,6 +27665,7 @@ function Reset-WmtLibraryToCatalog {
         if ($brdCatalogList) { $brdCatalogList.Visibility = "Visible" }
         if ($btnBackToCatalog) { $btnBackToCatalog.Visibility = "Collapsed" }
         if ($btnLibraryRefresh) { $btnLibraryRefresh.Visibility = "Collapsed" }
+        if ($btnToggleFabAssets) { $btnToggleFabAssets.Visibility = "Collapsed" }
         if ($lblLibraryStatus) { $lblLibraryStatus.Text = "" }
         if ($btnShowLibrary) { $btnShowLibrary.Style = ($window.FindResource("ActionBtn") -as [System.Windows.Style]) }
     }
@@ -27686,11 +27734,29 @@ $tabButton.Add_Click({
             elseif (-not $script:TweakStatesReady) {
                 # Background jobs disabled — do a one-time synchronous load with error fallback
                 Set-TweakStatesLoadingOverlay -Visible $true
+                                # Explicitly set the initial state of the two loads
+                                $script:OptionalFeaturesReady = $false
+                $script:TweakStatesReady = $false
+                                # Allows the UI to render the overlay before the heavy work begins
+                                $window.Dispatcher.Invoke(
+                    [System.Action]{},
+                    [System.Windows.Threading.DispatcherPriority]::Render
+                )
+                $optionalFeaturesLoaded = $false
+                $tweakStatesLoaded = $false
                 try {
                     $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                    Update-OptionalFeaturesSynchronously                                        
+                    $optionalFeaturesLoaded = $true                                     
+                                        $script:OptionalFeaturesReady = $true
+                    # Update the overlay immediately after the first load
+                    Sync-WmtTweakOverlayHide                                    
                     Update-TweakButtonStates
+                    $tweakStatesLoaded = $true
+                    $script:TweakStatesReady = $true                                    
+                                        # Update the overlay immediately after the second load
+                    Sync-WmtTweakOverlayHide
                     $sw.Stop()
-                    $script:TweakStatesReady = $true
                     if ($sw.ElapsedMilliseconds -gt 3000) {
                         try { Write-GuiLog "[Tweak States] Synchronous load completed slowly ($($sw.ElapsedMilliseconds)ms). Consider enabling background jobs in Settings." } catch {}
                     }
@@ -27698,11 +27764,14 @@ $tabButton.Add_Click({
                 catch {
                     $errMsg = $_.Exception.Message
                     try { Write-GuiLog "[Tweak States] ERROR: Failed to load tweak states: $errMsg" } catch {}
-                    $script:TweakStatesReady = $true
                     # Show error on overlay briefly before hiding
                     Show-TweakStatesLoadError -Message "Failed to load tweak states. Toggle buttons may show incorrect states. Click Retry or switch tabs and back. Error: $errMsg"
                 }
-                Sync-WmtTweakOverlayHide
+                finally {
+                    $script:OptionalFeaturesReady = $optionalFeaturesLoaded
+                    $script:TweakStatesReady = $tweakStatesLoaded
+                    Sync-WmtTweakOverlayHide
+                }
             }
         }
     })
@@ -29094,10 +29163,10 @@ $searchIndexDeferTimer.Add_Tick({
     Add-SearchIndexEntry "btnToggleTheme"       "Toggle Theme"                    "btnTabSupport"
     Add-SearchIndexEntry "btnDisableBgJobs"      "Background Jobs"                 "btnTabSupport"
     Add-SearchIndexAction "Disable Background Jobs" { Set-WmtDisableBackgroundJobs -Enabled $true; $btn = Get-Ctrl "btnDisableBgJobs"; if ($btn) { $btn.Content = "Background Jobs: Off" }; Write-GuiLog "Background jobs disabled." } "btnTabSupport"
-    Add-SearchIndexAction "Enable Background Jobs"  { Set-WmtDisableBackgroundJobs -Enabled $false; $btn = Get-Ctrl "btnDisableBgJobs"; if ($btn) { $btn.Content = "Background Jobs: On" }; Write-GuiLog "Background jobs enabled." } "btnTabSupport"
+    Add-SearchIndexAction "Enable Background Jobs"  { Set-WmtDisableBackgroundJobs -Enabled $false; $btn = Get-Ctrl "btnDisableBgJobs"; if ($btn) { $btn.Content = "Background Jobs: On" }; Write-GuiLog "Background jobs enabled."; try { Start-WmtBackgroundJobsNow } catch {} } "btnTabSupport"
     Add-SearchIndexEntry "btnDisableUpdateScans"  "Update Scans"                    "btnTabSupport"
     Add-SearchIndexAction "Disable Update Scans" { Set-WmtUpdateScansDisabled -Enabled $true; Update-WmtUpdateScansButton; Write-GuiLog "Update scans disabled." } "btnTabSupport"
-    Add-SearchIndexAction "Enable Update Scans"  { Set-WmtUpdateScansDisabled -Enabled $false; Update-WmtUpdateScansButton; Write-GuiLog "Update scans enabled." } "btnTabSupport"
+    Add-SearchIndexAction "Enable Update Scans"  { Set-WmtUpdateScansDisabled -Enabled $false; Update-WmtUpdateScansButton; Write-GuiLog "Update scans enabled."; try { if (-not (Get-WmtDisableBackgroundJobs)) { Start-WmtUpdateAutoScanTimer } } catch {} } "btnTabSupport"
     Add-SearchIndexEntry "btnStartWithWindows" "Start with Windows"              "btnTabSupport"
     Add-SearchIndexAction "Light Mode" { Set-WmtThemePreference -Theme "light" } "btnTabSupport"
     Add-SearchIndexAction "Dark Mode" { Set-WmtThemePreference -Theme "dark" }  "btnTabSupport"
@@ -29129,11 +29198,13 @@ $searchIndexDeferTimer.Add_Tick({
         if ($brdLibraryList) { $brdLibraryList.Visibility = "Visible" }
         if ($btnBackToCatalog) { $btnBackToCatalog.Visibility = "Visible" }
         if ($btnLibraryRefresh) { $btnLibraryRefresh.Visibility = "Visible" }
+        if ($btnToggleFabAssets) { $btnToggleFabAssets.Visibility = "Visible" }
         if ($btnShowLibrary) { $btnShowLibrary.Style = ($window.FindResource("AccentBtn") -as [System.Windows.Style]) }
         # Display pre-loaded results if available.
         if ($script:WmtLibraryScanResults -and $script:WmtLibraryScanResults.Count -gt 0 -and $lstLibrary) {
             $lstLibrary.Items.Clear()
             foreach ($item in $script:WmtLibraryScanResults) {
+                if (Test-WmtFabAssetHidden $item) { continue }
                 [void]$lstLibrary.Items.Add($item)
             }
             if ($lblLibraryStatus) { $lblLibraryStatus.Text = "$($lstLibrary.Items.Count) game(s) in your library." }
@@ -29388,8 +29459,13 @@ $lstWinget.Add_PreviewMouseRightButtonDown({
         Set-WmtListViewRightClickSelection -ListView $s -OriginalSource $e.OriginalSource
     })
 
+# Suppress the menu only when no row is selected (rows are selected by the
+# PreviewMouseRightButtonDown handler above). The sender/event args must come
+# from param(); the previous version referenced undefined variables and threw
+# an exception on every right-click, which aborted the menu open.
 $lstWinget.Add_ContextMenuOpening({
-    if ($s.SelectedItems.Count -eq 0) { $_.Handled = $true }
+    param($s, $e)
+    if (@($s.SelectedItems).Count -eq 0) { $e.Handled = $true }
 })
 
 $lstWinget.Add_PreviewKeyDown({
@@ -33258,9 +33334,13 @@ catch {
 $script:WmtLegendaryLibraryCache = $result.ToArray()
 
 # Write to cache file for use by the search runspace.
+# Guard: never wipe an existing cache with an empty result (e.g. legendary
+# failed mid-scan on a network outage) — keep the last good list instead.
 try {
     $cacheFile = Join-Path (Get-DataPath) "legendary_library.json"
-    $script:WmtLegendaryLibraryCache | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $cacheFile -Force -Encoding UTF8
+    if ($result.Count -gt 0 -or -not (Test-Path -LiteralPath $cacheFile -PathType Leaf)) {
+        $script:WmtLegendaryLibraryCache | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $cacheFile -Force -Encoding UTF8
+    }
 }
 catch {
     Write-GuiLog "Failed to write Legendary library cache: $($_.Exception.Message)"
@@ -37243,20 +37323,44 @@ $btnWingetScan.Add_Click({
                     $pInfo.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false)
                     $pInfo.StandardErrorEncoding = [System.Text.UTF8Encoding]::new($false)
 
-                    $p = [System.Diagnostics.Process]::Start($pInfo)
-                    $outTask = $p.StandardOutput.ReadToEndAsync()
-                    $errTask = $p.StandardError.ReadToEndAsync()
-                    if (-not $p.WaitForExit(90000)) {
-                        Write-Output "LOG:Legendary scan timed out after 90 seconds."
-                        try { $p.Kill() } catch {}
-                        try { [void]$p.WaitForExit(2000) } catch {}
-                        return
+                    # Epic endpoints intermittently fail with transient read timeouts
+                    # (legendary's HTTP client uses a 10s read timeout). Retry once on
+                    # network-class failures so a momentary blip does not kill the scan.
+                    $out = ""
+                    $err = ""
+                    $exitCode = 0
+                    $maxAttempts = 2
+                    $attempt = 0
+                    while ($true) {
+                        $attempt++
+                        $p = [System.Diagnostics.Process]::Start($pInfo)
+                        $outTask = $p.StandardOutput.ReadToEndAsync()
+                        $errTask = $p.StandardError.ReadToEndAsync()
+                        if (-not $p.WaitForExit(90000)) {
+                            Write-Output "LOG:Legendary scan timed out after 90 seconds."
+                            try { $p.Kill() } catch {}
+                            try { [void]$p.WaitForExit(2000) } catch {}
+                            return
+                        }
+
+                        $out = $outTask.GetAwaiter().GetResult()
+                        $err = $errTask.GetAwaiter().GetResult()
+                        $exitCode = $p.ExitCode
+
+                        # Success = clean exit with a CSV payload
+                        if ($exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($out)) { break }
+
+                        $networkFailure = (([string]$err) -match '(?i)ReadTimeout|Read timed out|socket\.timeout|ConnectTimeout|ConnectionError|Connection reset|Connection aborted|NewConnectionError|MaxRetryError|HTTPSConnectionPool|getaddrinfo failed|Temporary failure in name resolution|timed out')
+                        if ($networkFailure -and $attempt -lt $maxAttempts) {
+                            Write-Output "LOG:Legendary could not reach Epic servers (network timeout, attempt $attempt of $maxAttempts). Retrying in 3 seconds..."
+                            Start-Sleep -Seconds 3
+                            continue
+                        }
+                        break
                     }
 
-                    $out = $outTask.GetAwaiter().GetResult()
-                    $err = $errTask.GetAwaiter().GetResult()
-                    if ($p.ExitCode -ne 0) {
-                        Write-Output "LOG:Legendary scan exited with code $($p.ExitCode)."
+                    if ($exitCode -ne 0) {
+                        Write-Output "LOG:Legendary scan exited with code $exitCode."
                         if (-not [string]::IsNullOrWhiteSpace($err)) {
                             foreach ($errLine in ($err -split "`r?`n")) {
                                 if (-not [string]::IsNullOrWhiteSpace($errLine)) { Write-Output "LOG:Legendary: $errLine" }
@@ -37265,7 +37369,14 @@ $btnWingetScan.Add_Click({
                     }
 
                     if ([string]::IsNullOrWhiteSpace($out)) {
-                        if (-not [string]::IsNullOrWhiteSpace($err)) { Write-Output "LOG:Legendary returned no CSV output. Run 'legendary auth' if Epic login is not configured." }
+                        if (-not [string]::IsNullOrWhiteSpace($err)) {
+                            if (([string]$err) -match '(?i)ReadTimeout|Read timed out|socket\.timeout|ConnectTimeout|ConnectionError|Connection reset|Connection aborted|NewConnectionError|MaxRetryError|HTTPSConnectionPool|getaddrinfo failed|Temporary failure in name resolution|timed out') {
+                                Write-Output "LOG:Legendary could not reach Epic servers (network timeout). Check the connection and run the scan again."
+                            }
+                            else {
+                                Write-Output "LOG:Legendary returned no CSV output. Run 'legendary auth' if Epic login is not configured."
+                            }
+                        }
                         return
                     }
 
@@ -39183,6 +39294,51 @@ $script:InvokeWingetSearch = {
             Write-Output "PROVIDER_START:legendary"
             $script:provCount = 0
             Log "Searching Legendary library..."
+            # Respect the "Hide Unreal Engine / Fab assets" library toggle. This
+            # runspace cannot see script scope, so read it from settings.json
+            # (stored next to the Legendary library cache file).
+            $hideUe = $true
+            try {
+                if ($LegendaryCacheFile) {
+                    $wmtSettingsFile = Join-Path (Split-Path -Parent $LegendaryCacheFile) "settings.json"
+                    if (Test-Path -LiteralPath $wmtSettingsFile -PathType Leaf) {
+                        $wmtSettingsJson = [System.IO.File]::ReadAllText($wmtSettingsFile) | ConvertFrom-Json -ErrorAction Stop
+                        if ($wmtSettingsJson.PSObject.Properties["HideLegendaryUeAssets"]) { $hideUe = [bool]$wmtSettingsJson.HideLegendaryUeAssets }
+                    }
+                }
+            }
+            catch {}
+            # Legendary marks UE/Fab content with namespace 'ue' in its own assets.json.
+            # Use it as the authoritative filter (Fab app_names are arbitrary, e.g. "PlatformFunctionsPlugin_5.4").
+            $ueAppNames = @{}
+            $ueAssetsFiles = @()
+            try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".legendary\assets.json") } } catch {}
+            try { if ($env:APPDATA) { $ueAssetsFiles += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\assets.json") } } catch {}
+            foreach ($ueAssetsFile in $ueAssetsFiles) {
+                if (-not (Test-Path -LiteralPath $ueAssetsFile -PathType Leaf)) { continue }
+                try {
+                    $assetsJson = [System.IO.File]::ReadAllText($ueAssetsFile) | ConvertFrom-Json -ErrorAction Stop
+                    foreach ($platformProp in @($assetsJson.PSObject.Properties)) {
+                        # Platform value can be an array of assets (legendary) or a map of
+                        # app_name -> asset (heroic-style assets.json). Handle both.
+                        $uePlatformAssets = @()
+                        if ($platformProp.Value -is [System.Collections.IEnumerable] -and $platformProp.Value -isnot [string] -and $platformProp.Value -isnot [System.Management.Automation.PSCustomObject]) {
+                            $uePlatformAssets = @($platformProp.Value)
+                        }
+                        elseif ($platformProp.Value -and $platformProp.Value.PSObject) {
+                            $uePlatformAssets = @($platformProp.Value.PSObject.Properties | ForEach-Object { $_.Value })
+                        }
+                        foreach ($asset in @($uePlatformAssets)) {
+                            if (([string]$asset.namespace) -eq 'ue') {
+                                $ueKey = ([string]$asset.app_name).Trim().ToLowerInvariant()
+                                if ($ueKey) { $ueAppNames[$ueKey] = $true }
+                            }
+                        }
+                    }
+                }
+                catch {}
+                break
+            }
             try {
                 if ($LegendaryCacheFile -and (Test-Path -LiteralPath $LegendaryCacheFile -PathType Leaf)) {
                     $cacheText = [System.IO.File]::ReadAllText($LegendaryCacheFile)
@@ -39192,6 +39348,8 @@ $script:InvokeWingetSearch = {
                         foreach ($game in @($library)) {
                             $title = [string]$game.Title
                             if ([string]::IsNullOrWhiteSpace($title)) { continue }
+                            $legId = ([string]$game.Id).Trim()
+                            if ($hideUe -and ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$')) { continue }
                             if ([string]::IsNullOrWhiteSpace($needle) -or $title.ToLowerInvariant().Contains($needle)) {
                                 # Show installed version in Version column, latest in Available.
                                 $isInst = $false
@@ -39707,10 +39865,12 @@ $mniCopyAll.Add_Click({
 # Attach to the ListView
 # Prevent context menu from opening when right-clicking empty space, headers, or scrollbars
 $lstFw.Add_PreviewMouseRightButtonDown({
-    try { Set-WmtListViewRightClickSelection -ListView $lstFw -OriginalSource $_.OriginalSource } catch {}
+    param($s, $e)
+    try { Set-WmtListViewRightClickSelection -ListView $s -OriginalSource $e.OriginalSource } catch {}
 })
 $lstFw.Add_ContextMenuOpening({
-    if ($lstFw.SelectedItems.Count -eq 0) { $_.Handled = $true }
+    param($s, $e)
+    if (@($s.SelectedItems).Count -eq 0) { $e.Handled = $true }
 })
 
 # Attach to the ListView
@@ -40546,6 +40706,50 @@ $btnStartWithWindows.Add_Click({
     })
 }
 
+# Start the boot-time background jobs immediately. Called when Background Jobs
+# are re-enabled at runtime (Settings toggle or search action) so the user does
+# not have to restart WMT or revisit tabs to get stats, tweak states, caches and
+# the update auto-scan timer running.
+function Start-WmtBackgroundJobsNow {
+try {
+    # My Device stats (sections run in pooled runspaces; safe to kick from UI thread)
+    if (-not $script:MyDeviceStatsStarted) {
+        $script:MyDeviceStatsStarted = $true
+        Update-MyDeviceStats
+    }
+    elseif ($script:MyDeviceStatsLastDisabled) {
+        # Stats were last loaded while background jobs were disabled: the section
+        # collector timer never ran, so My Device still shows the "scanning is
+        # disabled" placeholders. Reload now — RAM-cached sections apply instantly.
+        Update-MyDeviceStats
+    }
+
+    # Tweak states + optional features background loads (each has a one-shot guard)
+    if (-not $script:TweakStatesReady) {
+        Start-TweakButtonStatesBackgroundUpdate
+        Start-OptionalFeaturesBackgroundCheck
+    }
+
+    # AppX bloatware list (normally triggered on first Tweaks tab visit)
+    if (-not $script:AppxListLoaded) {
+        $script:AppxListLoaded = $true
+        Start-AppxBackgroundLoad
+    }
+
+    # Legendary/GOG library cache for the Updates search box (self-guarding,
+    # refreshes only when a cache file is missing or older than 24 hours)
+    try { Start-WmtLibraryCacheBuilder } catch {}
+
+    # Periodic update auto-scan timer (requires update scans enabled too)
+    if (-not (Get-WmtUpdateScansDisabled)) {
+        try { Start-WmtUpdateAutoScanTimer } catch {}
+    }
+}
+catch {
+    try { Write-GuiLog "Background jobs failed to start: $($_.Exception.Message)" } catch {}
+}
+}
+
 # ── Background Jobs Toggle ──
 $btnDisableBgJobs = Get-Ctrl "btnDisableBgJobs"
 if ($btnDisableBgJobs) {
@@ -40566,11 +40770,18 @@ function Update-WmtDisableBgJobsButton {
 Update-WmtDisableBgJobsButton
 
 $btnDisableBgJobs.Add_Click({
-        $currentlyDisabled = Get-WmtDisableBackgroundJobs
+        $currentlyDisabled = [System.Convert]::ToBoolean((Get-WmtDisableBackgroundJobs))
         Set-WmtDisableBackgroundJobs -Enabled (-not $currentlyDisabled)
         Update-WmtDisableBgJobsButton
-        $newState = if (-not $currentlyDisabled) { 'enabled' } else { 'disabled' }
-        Write-GuiLog "Background jobs $newState. Changes take effect on next tab visit."
+        if ($currentlyDisabled) {
+            # Bg jobs were OFF, now ON — fire the boot-time jobs immediately
+            # instead of waiting for the next tab visit or an app restart.
+            Write-GuiLog "Background jobs enabled. Starting pending background jobs..."
+            try { Start-WmtBackgroundJobsNow } catch {}
+        }
+        else {
+            Write-GuiLog "Background jobs disabled. In-flight jobs will finish; new ones will not start."
+        }
     })
 }
 
@@ -40600,11 +40811,22 @@ function Update-WmtUpdateScansButton {
 Update-WmtUpdateScansButton
 
 $btnDisableUpdateScans.Add_Click({
-        $currentlyDisabled = Get-WmtUpdateScansDisabled
+        $currentlyDisabled = [System.Convert]::ToBoolean((Get-WmtUpdateScansDisabled))
         Set-WmtUpdateScansDisabled -Enabled (-not $currentlyDisabled)
         Update-WmtUpdateScansButton
         $newState = if (-not $currentlyDisabled) { 'disabled' } else { 'enabled' }
         Write-GuiLog "Update scans $newState."
+        if ($currentlyDisabled) {
+            # Update scans were OFF, now ON — restart the periodic auto-scan
+            # timer immediately (only when background jobs are also enabled).
+            if (-not (Get-WmtDisableBackgroundJobs)) {
+                try { Start-WmtUpdateAutoScanTimer } catch {}
+            }
+        }
+        else {
+            # Turning scans OFF — stop the periodic timer so no ticks fire at all.
+            try { Stop-WmtUpdateAutoScanTimer } catch {}
+        }
     })
 }
 if ($btnDonate) { $btnDonate.Add_Click({ Start-Process "https://github.com/sponsors/Chaython" }) }
@@ -41193,7 +41415,7 @@ $btnToggleTakeOwnership.Add_Click({
                 Write-GuiLog "Take Ownership context menu added (files, folders, drives)."
             } "Adding Take Ownership..."
         }
-        Update-WmtTweakToggle $btnToggleTakeOwnership (-not $installed) "Add Take Ownership" "Remove Take Ownership"
+        Update-WmtTweakToggle $btnToggleTakeOwnership (-not $installed) "Remove Take Ownership" "Add Take Ownership"
     })
 }
 
@@ -41217,7 +41439,7 @@ $btnTogglePsHere.Add_Click({
                 Write-GuiLog "PowerShell Here context menu added."
             } "Adding PowerShell Here..."
         }
-        Update-WmtTweakToggle $btnTogglePsHere (-not $installed) "Add PowerShell Here" "Remove PowerShell Here"
+        Update-WmtTweakToggle $btnTogglePsHere (-not $installed) "Remove PowerShell Here" "Add PowerShell Here"
     })
 }
 
@@ -41942,9 +42164,45 @@ $ps = New-WmtPooledPowerShell
                 $cacheText = [System.IO.File]::ReadAllText($LegCacheFile)
                 $library = $cacheText | ConvertFrom-Json -ErrorAction Stop
                 $legCount = 0
+                # Legendary marks UE/Fab content with namespace 'ue' in its own assets.json.
+                # Use it as the authoritative UE/Fab tag (Fab app_names are arbitrary, e.g. "PlatformFunctionsPlugin_5.4").
+                $ueAppNames = @{}
+                $ueAssetsFiles = @()
+                try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".legendary\assets.json") } } catch {}
+                try { if ($env:APPDATA) { $ueAssetsFiles += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\assets.json") } } catch {}
+                foreach ($ueAssetsFile in $ueAssetsFiles) {
+                    if (-not (Test-Path -LiteralPath $ueAssetsFile -PathType Leaf)) { continue }
+                    try {
+                        $assetsJson = [System.IO.File]::ReadAllText($ueAssetsFile) | ConvertFrom-Json -ErrorAction Stop
+                        foreach ($platformProp in @($assetsJson.PSObject.Properties)) {
+                            # Platform value can be an array of assets (legendary) or a map of
+                            # app_name -> asset (heroic-style assets.json). Handle both.
+                            $uePlatformAssets = @()
+                            if ($platformProp.Value -is [System.Collections.IEnumerable] -and $platformProp.Value -isnot [string] -and $platformProp.Value -isnot [System.Management.Automation.PSCustomObject]) {
+                                $uePlatformAssets = @($platformProp.Value)
+                            }
+                            elseif ($platformProp.Value -and $platformProp.Value.PSObject) {
+                                $uePlatformAssets = @($platformProp.Value.PSObject.Properties | ForEach-Object { $_.Value })
+                            }
+                            foreach ($asset in @($uePlatformAssets)) {
+                                if (([string]$asset.namespace) -eq 'ue') {
+                                    $ueKey = ([string]$asset.app_name).Trim().ToLowerInvariant()
+                                    if ($ueKey) { $ueAppNames[$ueKey] = $true }
+                                }
+                            }
+                        }
+                    }
+                    catch {}
+                    break
+                }
                 foreach ($game in @($library)) {
                     $title = [string]$game.Title
                     if ([string]::IsNullOrWhiteSpace($title)) { continue }
+                    # Tag Unreal Engine / Fab marketplace assets. The UI hides them
+                    # when the "Hide Unreal Engine / Fab assets" toggle is checked;
+                    # update checks are never affected by the toggle.
+                    $legId = ([string]$game.Id).Trim()
+                    $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$')
                     $isInst = $false
                     try { if ($game.PSObject.Properties["IsInstalled"]) { $isInst = [bool]$game.IsInstalled } } catch {}
                     $instVer = ""
@@ -41958,6 +42216,7 @@ $ps = New-WmtPooledPowerShell
                             Available   = if (-not [string]::IsNullOrWhiteSpace($latestVer)) { $latestVer } else { "-" }
                             IsInstalled = $isInst
                             ProviderKey = "legendary"
+                            IsUe        = $legIsUe
                         })
                     $legCount++
                 }
@@ -42040,6 +42299,7 @@ $script:WmtLibraryScanTimer.Add_Tick({
             if ($lstLibrary -and $brdLibraryList -and $brdLibraryList.Visibility -eq [System.Windows.Visibility]::Visible) {
                 $lstLibrary.Items.Clear()
                 foreach ($item in $script:WmtLibraryScanResults) {
+                    if (Test-WmtFabAssetHidden $item) { continue }
                     [void]$lstLibrary.Items.Add($item)
                 }
                 if ($lblLibraryStatus) {
@@ -42076,6 +42336,7 @@ $btnShowLibrary.Add_Click({
         $brdLibraryList.Visibility = "Visible"
         if ($btnBackToCatalog) { $btnBackToCatalog.Visibility = "Visible" }
         if ($btnLibraryRefresh) { $btnLibraryRefresh.Visibility = "Visible" }
+        if ($btnToggleFabAssets) { $btnToggleFabAssets.Visibility = "Visible" }
 
         # Highlight the Your Library button (AccentBtn style).
         if ($btnShowLibrary) { $btnShowLibrary.Style = ($window.FindResource("AccentBtn") -as [System.Windows.Style]) }
@@ -42084,6 +42345,7 @@ $btnShowLibrary.Add_Click({
         if ($script:WmtLibraryScanResults -and $script:WmtLibraryScanResults.Count -gt 0) {
             $lstLibrary.Items.Clear()
             foreach ($item in $script:WmtLibraryScanResults) {
+                if (Test-WmtFabAssetHidden $item) { continue }
                 [void]$lstLibrary.Items.Add($item)
             }
             if ($lblLibraryStatus) {
@@ -42104,6 +42366,7 @@ $btnBackToCatalog.Add_Click({
         $brdCatalogList.Visibility = "Visible"
         if ($btnBackToCatalog) { $btnBackToCatalog.Visibility = "Collapsed" }
         if ($btnLibraryRefresh) { $btnLibraryRefresh.Visibility = "Collapsed" }
+        if ($btnToggleFabAssets) { $btnToggleFabAssets.Visibility = "Collapsed" }
         if ($lblLibraryStatus) { $lblLibraryStatus.Text = "" }
 
         # Restore the Your Library button to ActionBtn style (gray).
@@ -42113,6 +42376,32 @@ $btnBackToCatalog.Add_Click({
 $btnLibraryRefresh.Add_Click({
         Start-WmtLibraryScan
     })
+
+# --- Unreal Engine / Fab assets visibility toggle (Your Library) ---
+# Hides UE/Fab assets from the library view only; update scans for them
+# are never disabled. Persisted in settings.json as HideLegendaryUeAssets.
+# State lives in $global:WmtHideUeAssets (see Test-WmtFabAssetHidden) so the
+# search debounce and every list population path share one live value.
+if ($btnToggleFabAssets) {
+$btnToggleFabAssets.Add_Click({
+        $global:WmtHideUeAssets = -not $global:WmtHideUeAssets
+        try {
+            $wmtUeSettings = Get-WmtSettings
+            if ($wmtUeSettings -is [System.Collections.IDictionary]) { $wmtUeSettings["HideLegendaryUeAssets"] = [bool]$global:WmtHideUeAssets }
+            else { $wmtUeSettings | Add-Member -MemberType NoteProperty -Name "HideLegendaryUeAssets" -Value ([bool]$global:WmtHideUeAssets) -Force }
+            Save-WmtSettings -Settings $wmtUeSettings
+        }
+        catch {}
+        Set-WmtFabAssetsButtonLabel
+        # Re-apply the filter instantly; Update-WmtLibrarySearch respects any
+        # active search text and the shared hide flag.
+        Update-WmtLibrarySearch
+        if ($lblLibraryStatus -and $brdLibraryList -and $brdLibraryList.Visibility -eq "Visible" -and $lstLibrary -and $lstLibrary.Items.Count -gt 0) {
+            $lblLibraryStatus.Text = "$($lstLibrary.Items.Count) game(s) in your library."
+        }
+        Write-GuiLog ("Unreal Engine / Fab assets are now " + $(if ($global:WmtHideUeAssets) { "hidden" } else { "shown" }) + " in Your Library. Update checks are unaffected.")
+    })
+}
 
 # --- Library context menu ---
 # Helper: get the selected library item.
@@ -42637,12 +42926,14 @@ function Update-WmtLibrarySearch {
     if ([string]::IsNullOrWhiteSpace($query)) {
         # No filter � show all.
         foreach ($item in $script:WmtLibraryScanResults) {
+            if (Test-WmtFabAssetHidden $item) { continue }
             [void]$lstLibrary.Items.Add($item)
         }
     }
     else {
         $needle = $query.ToLowerInvariant()
         foreach ($item in $script:WmtLibraryScanResults) {
+            if (Test-WmtFabAssetHidden $item) { continue }
             $name = ([string]$item.Name).ToLowerInvariant()
             $id = ([string]$item.Id).ToLowerInvariant()
             $source = ([string]$item.Source).ToLowerInvariant()
@@ -42703,7 +42994,6 @@ if ($txtLibrarySearch) {
     $script:WmtLibrarySearchTimer.Add_Tick({
             try { $script:WmtLibrarySearchTimer.Stop() } catch {}
             Update-WmtLibrarySearch
-            $script:WmtLibrarySearchTimer = $null
         }.GetNewClosure())
 }
 
@@ -43084,8 +43374,8 @@ function Sync-WmtTweakOverlayHide {
 # states background job AND the optional features background check have
 # completed.  Updates the overlay subtitle so the user knows what's still loading.
 try {
-    $tweakStatesDone = $script:TweakStatesReady
-    $optFeaturesDone = $script:OptionalFeaturesReady
+    $tweakStatesDone = [bool]$script:TweakStatesReady
+    $optFeaturesDone = [bool]$script:OptionalFeaturesReady
     if ($tweakStatesDone -and $optFeaturesDone) {
         Set-TweakStatesLoadingOverlay -Visible $false
     }
@@ -43095,6 +43385,18 @@ try {
         Set-TweakStatesLoadingOverlay -Visible $true
         $sub = Get-Ctrl "txtTweakOverlaySubtitle"
         if ($sub) { $sub.Text = "Tweak buttons loaded. Checking optional features (.NET, WSL, Hyper-V...)" }
+        }
+    elseif (-not $tweakStatesDone -and $optFeaturesDone) {
+        # Optional features are ready, but tweak toggle buttons are still loading.
+        Set-TweakStatesLoadingOverlay -Visible $true
+        $sub = Get-Ctrl "txtTweakOverlaySubtitle"
+        if ($sub) { $sub.Text = "Optional features loaded. Loading tweak buttons..." }
+    }
+    else {
+        # Both tweak states and optional features are still loading.
+        Set-TweakStatesLoadingOverlay -Visible $true
+        $sub = Get-Ctrl "txtTweakOverlaySubtitle"
+        if ($sub) { $sub.Text = "Loading tweak buttons and checking optional features..." }
     }
 } catch {}
 }
@@ -43485,6 +43787,26 @@ $script:TweakStatesBgTimeout.Add_Tick({
 $script:TweakStatesBgTimeout.Start()
 }
 
+$script:OptionalFeaturesMap = @{
+    "Microsoft-Hyper-V-All"              = "btnFeatHyperV"
+    "Microsoft-Windows-Subsystem-Linux"  = "btnFeatWSL"
+    "Containers-DisposableClientVM"      = "btnFeatSandbox"
+    "NetFx3"                             = "btnFeatDotNet35"
+    "ServicesForNFS-ClientOnly"          = "btnFeatNFS"
+    "TelnetClient"                       = "btnFeatTelnet"
+    "IIS-WebServerRole"                  = "btnFeatIIS"
+    "WindowsMediaPlayer"                 = "btnFeatLegacy"
+    "VirtualMachinePlatform"             = "btnFeatVMP"
+    "HypervisorPlatform"                 = "btnFeatWHP"
+    "OpenSSH.Client"                     = "btnFeatSSHClient"
+    "OpenSSH.Server"                     = "btnFeatSSHServer"
+    "Windows-Defender-ApplicationGuard"  = "btnFeatAppGuard"
+    "WirelessDisplay"                    = "btnFeatMiracast"
+    "QuickAssist"                        = "btnFeatQuickAssist"
+    "XpsViewer"                          = "btnFeatXPS"
+    "TIFFIFilter"                        = "btnFeatTIFF"
+}
+
 function Start-OptionalFeaturesBackgroundCheck {
 # Check all optional features in a SINGLE query (not 17 separate calls).
 # Runs only ONCE, deferred until the user first visits the Tweaks tab
@@ -43493,25 +43815,7 @@ if ($script:OptionalFeaturesCheckStarted) { return }
 $script:OptionalFeaturesCheckStarted = $true
 
 # Map feature names to button names
-$featureMap = @{
-    "Microsoft-Hyper-V-All"             = "btnFeatHyperV"
-    "Microsoft-Windows-Subsystem-Linux" = "btnFeatWSL"
-    "Containers-DisposableClientVM"     = "btnFeatSandbox"
-    "NetFx3"                            = "btnFeatDotNet35"
-    "ServicesForNFS-ClientOnly"         = "btnFeatNFS"
-    "TelnetClient"                      = "btnFeatTelnet"
-    "IIS-WebServerRole"                 = "btnFeatIIS"
-    "WindowsMediaPlayer"                = "btnFeatLegacy"
-    "VirtualMachinePlatform"            = "btnFeatVMP"
-    "HypervisorPlatform"                = "btnFeatWHP"
-    "OpenSSH.Client"                    = "btnFeatSSHClient"
-    "OpenSSH.Server"                    = "btnFeatSSHServer"
-    "Windows-Defender-ApplicationGuard" = "btnFeatAppGuard"
-    "WirelessDisplay"                   = "btnFeatMiracast"
-    "QuickAssist"                       = "btnFeatQuickAssist"
-    "XpsViewer"                         = "btnFeatXPS"
-    "TIFFIFilter"                       = "btnFeatTIFF"
-}
+$featureMap = $script:OptionalFeaturesMap
 
 # Run in a background runspace (shared pool)
 $ps = New-WmtPooledPowerShell
@@ -43605,6 +43909,69 @@ $script:FeaturesCheckTimer.Add_Tick({
         }
     })
 $script:FeaturesCheckTimer.Start()
+}
+
+function Update-OptionalFeaturesSynchronously {
+    $featureMap = $script:OptionalFeaturesMap
+    $results = @{}
+    $useCmdlet = $false
+    try {
+        if (Get-Command Get-WindowsOptionalFeature -ErrorAction SilentlyContinue) {
+            $useCmdlet = $true
+        }
+    }
+    catch {}
+    if ($useCmdlet) {
+        try {
+            Write-GuiLog "[Optional Features] Querying all features with PowerShell..."
+            $allFeatures = Get-WindowsOptionalFeature -Online -ErrorAction SilentlyContinue
+            if ($allFeatures) {
+                foreach ($feat in $allFeatures) {
+                    $btnName = $featureMap[$feat.FeatureName]
+                    if ($btnName) {
+                        $results[$btnName] = ($feat.State -eq "Enabled")
+                    }
+                }
+            }
+        }
+        catch {
+            try { Write-GuiLog "[Optional Features] PowerShell query failed: $($_.Exception.Message)" } catch {}
+        }
+    }
+    if ($results.Count -eq 0) {
+        try {
+            Write-GuiLog "[Optional Features] Querying all features with DISM..."
+            $output = Invoke-WmtCliText `
+                -FilePath "dism" `
+                -Arguments "/Online /Get-Features" `
+                -TimeoutMs 120000
+            foreach ($featureName in $featureMap.Keys) {
+                $btnName = $featureMap[$featureName]
+                if ($output -match "(?s)Feature Name :\s*$([regex]::Escape($featureName))\s*\r?\n.*?State\s*:\s*Enabled") {
+                    $results[$btnName] = $true
+                }
+                else {
+                    $results[$btnName] = $false
+                }
+            }
+        }
+        catch {
+            try { Write-GuiLog "[Optional Features] DISM query failed: $($_.Exception.Message)" } catch {}
+        }
+    }
+    foreach ($btnName in $results.Keys) {
+        $btn = Get-Ctrl $btnName
+        if (-not $btn) { continue }
+        if ($results[$btnName]) {
+            $btn.Style = ($window.FindResource("AccentBtn") -as [System.Windows.Style])
+            $btn.ToolTip = "Current state: Enabled (Blue = installed/active)`nClick to uninstall this feature (Gray).`nRestart recommended after toggling.`n`nOptional Windows feature. See card description for details."
+        }
+        else {
+            $btn.Style = ($window.FindResource("ActionBtn") -as [System.Windows.Style])
+            $btn.ToolTip = "Current state: Disabled (Gray = not installed)`nClick to install this feature (Blue).`nRestart recommended after toggling.`n`nOptional Windows feature. See card description for details."
+        }
+    }
+    Write-GuiLog "[Optional Features] Synchronous detection completed. Buttons updated: $($results.Count)"
 }
 
 $onMainWindowContentRendered = {
@@ -43967,7 +44334,11 @@ try {
                     }
 
                     $arr = $result.ToArray()
-                    $arr | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $LegCacheFile -Force -Encoding UTF8
+                    # Guard: never wipe an existing cache with an empty result (e.g. a
+                    # network outage during the fetch) — keep the last good list.
+                    if ($arr.Count -gt 0 -or -not (Test-Path -LiteralPath $LegCacheFile -PathType Leaf)) {
+                        $arr | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $LegCacheFile -Force -Encoding UTF8
+                    }
                     Write-Output "LOG:Legendary library cached: $($arr.Count) games."
                 }
                 catch {
@@ -44492,11 +44863,11 @@ if ($script:WmtDispatcherUnhandledHandler) {
 $script:WmtDispatcherUnhandledHandler = [System.Windows.Threading.DispatcherUnhandledExceptionEventHandler] {
     param($s, $eA)
 
-    try { $eventArgs.Handled = $true } catch {}
+    try { $eA.Handled = $true } catch {}
     try {
-        Write-WmtLastCrash -Context "Unhandled WPF dispatcher exception" -Exception $eventArgs.Exception
+        Write-WmtLastCrash -Context "Unhandled WPF dispatcher exception" -Exception $eA.Exception
         if ($script:WingetJob -or $script:WingetActiveAction) {
-            Reset-WmtUpdateUiAfterMonitorError -Context "Unhandled WPF dispatcher exception" -Exception $eventArgs.Exception -SkipCrashWrite
+            Reset-WmtUpdateUiAfterMonitorError -Context "Unhandled WPF dispatcher exception" -Exception $eA.Exception -SkipCrashWrite
         }
     }
     catch {}

--- a/WMT-GUI.ps1
+++ b/WMT-GUI.ps1
@@ -197,6 +197,20 @@ if ($script:LogBox) {
 }
 }
 
+function Remove-WmtGuiLogMessage {
+param([string]$Message)
+if (-not $script:LogBox -or [string]::IsNullOrWhiteSpace($Message)) { return }
+
+try {
+    $lines = @($script:LogBox.Text -split "\r?\n" | Where-Object {
+        $_ -and $_ -notmatch ('^\[[^\]]+\]\s*' + [regex]::Escape($Message) + '\s*$')
+    })
+    $script:LogBox.Text = if ($lines.Count -gt 0) { ($lines -join "`n") + "`n" } else { "" }
+    $script:LogBox.ScrollToEnd()
+}
+catch {}
+}
+
 function ConvertTo-WmtVersion {
 param([string]$VersionText)
 
@@ -36593,11 +36607,24 @@ param([switch]$ResetNextRun)
 
 $minutes = Get-WmtUpdateAutoScanMinutes
 
+$updateScansDisabled = Get-WmtUpdateScansDisabled
+if ($updateScansDisabled) {
+    $disabledMessagePattern = '(?m)^\[[^\]]+\]\s*' + [regex]::Escape("Update auto scan is disabled.") + '\s*$'
+    if (-not $script:LogBox -or $script:LogBox.Text -notmatch $disabledMessagePattern) {
+        Write-GuiLog "Update auto scan is disabled."
+    }
+}
+else {
+    # Re-enabling background jobs or update scans can revisit this path with a
+    # zero-minute interval. Remove the old disabled status instead of retaining
+    # a stale final line in the activity log.
+    Remove-WmtGuiLogMessage -Message "Update auto scan is disabled."
+}
+
 # DispatcherTimer is not IDisposable. Stop it and detach the Tick handler instead.
 Stop-WmtUpdateAutoScanTimer
 
 if ($minutes -le 0) {
-    Write-GuiLog "Update auto scan is disabled."
     return
 }
 

--- a/WMT-GUI.ps1
+++ b/WMT-GUI.ps1
@@ -1957,7 +1957,11 @@ return $pool
 
 function Get-WmtBackgroundRunspacePool {
 if (-not $script:WmtBackgroundPool) {
-    Initialize-WmtBackgroundRunspacePool
+    # Initialize RETURNS the pool object; discard it so this function emits
+    # exactly one object. The leaked return used to hand the first caller
+    # TWO pool objects (an array), which then tripped the old pool-health
+    # checks with reports like "state: Opened Opened" for a healthy pool.
+    $null = Initialize-WmtBackgroundRunspacePool
 }
 return $script:WmtBackgroundPool
 }
@@ -1978,24 +1982,42 @@ if ($script:WmtBackgroundPool) {
 # Falls back to standalone if the pool is unavailable or closed.
 function New-WmtPooledPowerShell {
 try {
-    $pool = Get-WmtBackgroundRunspacePool
+    $pool = $null
+    try { $pool = Get-WmtBackgroundRunspacePool } catch { $pool = $null }
     if (-not $pool) { return [PowerShell]::Create() }
-    # Check if pool is still open — if it was disposed/closed, fall back to standalone
-    if ($pool.IsDisposed -or ($pool.RunspacePoolStateInfo -and $pool.RunspacePoolStateInfo.State -ne 'Opened')) {
-        try { Write-GuiLog "[RunspacePool] Pool is no longer open (state: $($pool.RunspacePoolStateInfo.State)). Falling back to standalone runspace." } catch {}
-        return [PowerShell]::Create()
+
+    # Guard the stored value itself: anything that is not exactly one
+    # RunspacePool (a stray collection, for instance) makes every health
+    # guess below misfire - that is what once printed "state: Opened
+    # Opened" for a perfectly healthy pool and bounced every worker to a
+    # standalone runspace. Reset and rebuild instead of guessing.
+    if ($pool -isnot [System.Management.Automation.Runspaces.RunspacePool]) {
+        try {
+            foreach ($item in @($pool)) {
+                if ($item -is [System.Management.Automation.Runspaces.RunspacePool]) { $item.Dispose() }
+            }
+        } catch {}
+        $script:WmtBackgroundPool = $null
+        try { $pool = Get-WmtBackgroundRunspacePool } catch { $pool = $null }
+        if (-not $pool) { return [PowerShell]::Create() }
     }
+
     $ps = [PowerShell]::Create()
     try {
+        # Assigning the pool is itself the authoritative health check: a
+        # closed, broken or disposed pool raises right here, so no
+        # state-name string comparison is left to guess with.
         $ps.RunspacePool = $pool
+        return $ps
     }
     catch {
-        # Pool may have been closed between the check above and the assignment
-        try { Write-GuiLog "[RunspacePool] Failed to assign pool to PowerShell: $($_.Exception.Message). Using standalone." } catch {}
-        $ps.Dispose()
+        try { Write-GuiLog "[RunspacePool] Pool rejected a worker ($($_.Exception.Message)); a fresh pool will be built for the next job." } catch {}
+        try { $pool.Close() } catch {}
+        try { $pool.Dispose() } catch {}
+        $script:WmtBackgroundPool = $null
+        try { $ps.Dispose() } catch {}
         return [PowerShell]::Create()
     }
-    return $ps
 }
 catch {
     return [PowerShell]::Create()
@@ -3018,6 +3040,33 @@ foreach ($column in $Columns) {
 }
 }
 
+# --- SCHEDULED TASKS ENGINE (native Task Scheduler COM API) ---
+# Every scheduled-task view and toggle in this tool goes through the Task
+# Scheduler's own COM interface (Schedule.Service) - the same API schtasks.exe
+# uses. The ScheduledTasks module cmdlets wrap a CIM layer that fails wholesale
+# on some Windows 10 machines ("Value cannot be null. Parameter name: key"),
+# which used to blank the task lists and fail every telemetry toggle even
+# though the Task Scheduler service itself was healthy. The COM API does
+# exact-path lookups in milliseconds and never depends on WMI/CIM health.
+function New-WmtTaskSchedulerService {
+if ($script:WmtTaskService) {
+    # Re-validate a cached connection (the service may have been stopped or
+    # its RCW released since the last call); fall through to a fresh connect.
+    try { [void]$script:WmtTaskService.GetFolder("\"); return $script:WmtTaskService } catch { $script:WmtTaskService = $null }
+}
+
+try {
+    $service = New-Object -ComObject "Schedule.Service"
+    $service.Connect()
+    $script:WmtTaskService = $service
+    return $service
+}
+catch {
+    $script:WmtTaskService = $null
+    return $null
+}
+}
+
 function ConvertTo-WmtScheduledTaskIdentity {
 param(
     [string]$FullName = "",
@@ -3050,64 +3099,311 @@ $full = if ($TaskPath -eq "\") { "\$TaskName" } else { "$TaskPath$TaskName" }
 }
 }
 
-function Get-WmtScheduledTaskByIdentity {
+function ConvertFrom-WmtRegisteredTask {
 param(
-    [string]$FullName = "",
-    [string]$TaskName = "",
-    [string]$TaskPath = ""
+    $Task,
+    [string]$FallbackTaskName = "",
+    [string]$FallbackTaskPath = "\"
 )
 
-$id = ConvertTo-WmtScheduledTaskIdentity -FullName $FullName -TaskName $TaskName -TaskPath $TaskPath
-if ([string]::IsNullOrWhiteSpace($id.TaskName)) { return $null }
+# Property reads on a registered task can throw for tasks with damaged XML or
+# locked-down principals, so every read is guarded and the identity falls back
+# to caller-supplied values when the object will not cooperate.
+$taskName = ([string]$FallbackTaskName).Trim()
+try { $taskName = ([string]$Task.Name).Trim() } catch {}
 
-try {
-    return Get-ScheduledTask -TaskName $id.TaskName -TaskPath $id.TaskPath -ErrorAction Stop | Select-Object -First 1
+$taskPath = ""
+try { $taskPath = ([string]$Task.Path).Trim() } catch {}
+
+$id = if (-not [string]::IsNullOrWhiteSpace($taskPath)) {
+    ConvertTo-WmtScheduledTaskIdentity -FullName $taskPath
 }
-catch {
+else {
+    ConvertTo-WmtScheduledTaskIdentity -TaskName $taskName -TaskPath $FallbackTaskPath
+}
+
+$state = "Unknown"
+try {
+    switch ([int]$Task.State) {
+        0 { $state = "Unknown" }
+        1 { $state = "Disabled" }
+        2 { $state = "Queued" }
+        3 { $state = "Ready" }
+        4 { $state = "Running" }
+        default { $state = "Unknown" }
+    }
+}
+catch {}
+
+$enabled = ($state -ne "Disabled")
+try { $enabled = [bool]$Task.Enabled } catch {}
+
+$author = ""
+try { $author = [string]$Task.Definition.RegistrationInfo.Author } catch {}
+$description = ""
+try { $description = [string]$Task.Definition.RegistrationInfo.Description } catch {}
+
+[PSCustomObject]@{
+    TaskName    = [string]$id.TaskName
+    TaskPath    = [string]$id.TaskPath
+    State       = $state
+    Enabled     = $enabled
+    Author      = $author
+    Description = $description
+    FullName    = [string]$id.FullName
+}
+}
+
+function Get-WmtAllRegisteredTasks {
+param([Parameter(Mandatory = $true)]$Service)
+
+# Iterative walk of the task folder tree. GetTasks(1) also lists hidden tasks
+# (matching what the module cmdlets returned); a folder that refuses
+# enumeration is skipped instead of aborting the whole listing.
+$tasks = [System.Collections.ArrayList]::new()
+$stack = [System.Collections.Generic.Stack[object]]::new()
+try { $stack.Push($Service.GetFolder("\")) } catch { return @($tasks) }
+while ($stack.Count -gt 0) {
+    $folder = $stack.Pop()
     try {
-        return Get-ScheduledTask -ErrorAction Stop | Where-Object { $_.TaskName -eq $id.TaskName -and $_.TaskPath -eq $id.TaskPath } | Select-Object -First 1
+        foreach ($task in @($folder.GetTasks(1))) { [void]$tasks.Add($task) }
+    }
+    catch {}
+    try {
+        foreach ($subFolder in @($folder.GetFolders(0))) { $stack.Push($subFolder) }
     }
     catch {}
 }
-return $null
+return @($tasks)
 }
 
 function Get-WmtScheduledTaskRows {
 param(
     [string[]]$FullPaths = @(),
-    [string[]]$TaskPaths = @()
+    [string[]]$TaskPaths = @(),
+    [string[]]$TelemetryFolders = @()
 )
 
-$tasks = @()
-if ($FullPaths -and $FullPaths.Count -gt 0) {
-    foreach ($fullPath in $FullPaths) {
-        $task = Get-WmtScheduledTaskByIdentity -FullName $fullPath
-        if ($task) { $tasks += $task }
+$raw = @()
+$service = New-WmtTaskSchedulerService
+
+if (-not $service) {
+    # No Task Scheduler connection: keep explicit rows for every requested
+    # task so the grid always shows what was asked for (and why it failed).
+    foreach ($fullPath in @($FullPaths)) {
+        $id = ConvertTo-WmtScheduledTaskIdentity -FullName $fullPath
+        if ([string]::IsNullOrWhiteSpace($id.TaskName)) { continue }
+        $raw += [PSCustomObject]@{
+            TaskName    = [string]$id.TaskName
+            TaskPath    = [string]$id.TaskPath
+            State       = "ReadError"
+            Enabled     = $false
+            Author      = ""
+            Description = "Task Scheduler service is unavailable."
+            FullName    = [string]$id.FullName
+        }
+    }
+    if (@($FullPaths).Count -eq 0) {
+        $raw += [PSCustomObject]@{
+            TaskName    = "Task Scheduler unavailable"
+            TaskPath    = ""
+            State       = "ReadError"
+            Enabled     = $false
+            Author      = ""
+            Description = "Could not connect to the Task Scheduler COM service. Run WMT elevated and verify the Task Scheduler service is running."
+            FullName    = ""
+        }
+    }
+}
+elseif ($TelemetryFolders -and $TelemetryFolders.Count -gt 0) {
+    # Live "invoke the Task Scheduler" enumeration: walk every telemetry
+    # folder and list ALL tasks the scheduler actually has there (GetTasks(1)
+    # includes hidden tasks) instead of assuming a fixed name list - Windows
+    # builds vary; machines are missing some of the canonical nine while
+    # carrying extra CEIP/Appraiser/Siuf sub-tasks no fixed list knows.
+    # Folders that do not exist on this install raise 0x80070002 and are
+    # simply skipped (no tasks registered there). The Office folder mixes
+    # telemetry agents with unrelated servicing tasks, so its tasks are
+    # name-filtered at read time.
+    $seen = @{}
+    foreach ($folderPath in @($TelemetryFolders)) {
+        try {
+            # GetFolder takes the path WITHOUT a trailing backslash.
+            $folder = $service.GetFolder(([string]$folderPath).TrimEnd("\"))
+            $isOffice = (([string]$folderPath).TrimEnd("\") -eq "\Microsoft\Office")
+            foreach ($task in @($folder.GetTasks(1))) {
+                if ($isOffice) {
+                    $officeName = ""
+                    try { $officeName = [string]$task.Name } catch {}
+                    if ($officeName -notmatch "(?i)telemetry|apphealth|crash|consent") { continue }
+                }
+                $row = ConvertFrom-WmtRegisteredTask -Task $task
+                $key = ([string]$row.FullName).ToLowerInvariant()
+                if ([string]::IsNullOrWhiteSpace($key) -or $seen.ContainsKey($key)) { continue }
+                $seen[$key] = $true
+                $raw += $row
+            }
+        }
+        catch {}
+    }
+    # Merge the canonical button paths (deduped against the walk: tasks the
+    # walk already returned are listed from their live folder state; only the
+    # ones this machine is missing are new here, as explicit NotFound /
+    # ReadError rows so the grid always explains what the buttons target).
+    foreach ($fullPath in @($FullPaths)) {
+        $id = ConvertTo-WmtScheduledTaskIdentity -FullName $fullPath
+        if ([string]::IsNullOrWhiteSpace($id.TaskName)) { continue }
+        $key = ([string]$id.FullName).ToLowerInvariant()
+        if ($seen.ContainsKey($key)) { continue }
+        $seen[$key] = $true
+        try {
+            $canonicalFolder = ([string]$id.TaskPath).TrimEnd("\")
+            if ([string]::IsNullOrWhiteSpace($canonicalFolder)) { $canonicalFolder = "\" }
+            $folder = $service.GetFolder($canonicalFolder)
+            $task = $folder.GetTask([string]$id.TaskName)
+            if ($task) {
+                $raw += ConvertFrom-WmtRegisteredTask -Task $task -FallbackTaskName $id.TaskName -FallbackTaskPath $id.TaskPath
+            }
+            else {
+                $raw += [PSCustomObject]@{
+                    TaskName    = [string]$id.TaskName
+                    TaskPath    = [string]$id.TaskPath
+                    State       = "NotFound"
+                    Enabled     = $false
+                    Author      = ""
+                    Description = "Task is not registered on this system."
+                    FullName    = [string]$id.FullName
+                }
+            }
+        }
+        catch {
+            $hr = 0
+            try { $hr = $_.Exception.HResult } catch {}
+            $message = [string]$_.Exception.Message
+            $notFound = ($hr -eq -2147024894 -or $message -match '(?i)(cannot find|not found|does not exist|0x80070002)')
+            $raw += [PSCustomObject]@{
+                TaskName    = [string]$id.TaskName
+                TaskPath    = [string]$id.TaskPath
+                State       = if ($notFound) { "NotFound" } else { "ReadError" }
+                Enabled     = $false
+                Author      = ""
+                Description = if ($notFound) { "Task is not registered on this system." } else { $message }
+                FullName    = [string]$id.FullName
+            }
+        }
+    }
+    # Sort by folder then name so related tasks read as a block.
+    $raw = @($raw | Sort-Object TaskPath, TaskName)
+}
+elseif ($FullPaths -and $FullPaths.Count -gt 0) {
+    foreach ($fullPath in @($FullPaths)) {
+        $id = ConvertTo-WmtScheduledTaskIdentity -FullName $fullPath
+        if ([string]::IsNullOrWhiteSpace($id.TaskName)) { continue }
+        try {
+            # Exact-path COM lookup: no wildcard layer, no full-store scan.
+            # ITaskService has no GetTask member - tasks are opened through
+            # their folder (the same two-step the device-health probe uses).
+            # A missing folder raises 0x80070002, classified as NotFound below.
+            # GetFolder's documented path format carries NO trailing backslash
+            # ("Do not use a backslash following the last folder name in the
+            # path" - ITaskService::GetFolder), while the identity's TaskPath
+            # keeps one for display; strip it before every folder open.
+            $folderPath = ([string]$id.TaskPath).TrimEnd("\")
+            if ([string]::IsNullOrWhiteSpace($folderPath)) { $folderPath = "\" }
+            $folder = $service.GetFolder($folderPath)
+            $task = $folder.GetTask([string]$id.TaskName)
+            if ($task) {
+                $raw += ConvertFrom-WmtRegisteredTask -Task $task -FallbackTaskName $id.TaskName -FallbackTaskPath $id.TaskPath
+            }
+            else {
+                $raw += [PSCustomObject]@{
+                    TaskName    = [string]$id.TaskName
+                    TaskPath    = [string]$id.TaskPath
+                    State       = "NotFound"
+                    Enabled     = $false
+                    Author      = ""
+                    Description = "Task is not registered on this system."
+                    FullName    = [string]$id.FullName
+                }
+            }
+        }
+        catch {
+            # Missing or unreadable tasks stay visible as explicit rows instead
+            # of silently vanishing; the classification matches the task probe
+            # used by the device-health scan (HRESULT 0x80070002 family or a
+            # not-found message means absent, anything else is a read error).
+            $hr = 0
+            try { $hr = $_.Exception.HResult } catch {}
+            $message = [string]$_.Exception.Message
+            $notFound = ($hr -eq -2147024894 -or $message -match '(?i)(cannot find|not found|does not exist|0x80070002)')
+            $raw += [PSCustomObject]@{
+                TaskName    = [string]$id.TaskName
+                TaskPath    = [string]$id.TaskPath
+                State       = if ($notFound) { "NotFound" } else { "ReadError" }
+                Enabled     = $false
+                Author      = ""
+                Description = if ($notFound) { "Task is not registered on this system." } else { $message }
+                FullName    = [string]$id.FullName
+            }
+        }
     }
 }
 else {
     try {
-        $tasks = @(Get-ScheduledTask -ErrorAction Stop)
+        $comTasks = @(Get-WmtAllRegisteredTasks -Service $service)
         if ($TaskPaths -and $TaskPaths.Count -gt 0) {
             $normalizedPaths = @($TaskPaths | ForEach-Object { (ConvertTo-WmtScheduledTaskIdentity -TaskPath $_ -TaskName "_").TaskPath })
-            $tasks = @($tasks | Where-Object { $_.TaskPath -in $normalizedPaths })
+            $comTasks = @($comTasks | Where-Object {
+                    $taskPath = ""
+                    try { $taskPath = ([string]$_.Path).Trim() } catch {}
+                    if ([string]::IsNullOrWhiteSpace($taskPath)) { $false }
+                    else {
+                        $taskId = ConvertTo-WmtScheduledTaskIdentity -FullName $taskPath
+                        $taskId.TaskPath -in $normalizedPaths
+                    }
+                })
+        }
+        foreach ($task in @($comTasks)) {
+            $raw += ConvertFrom-WmtRegisteredTask -Task $task
+        }
+        if ($comTasks.Count -eq 0 -and @($TaskPaths).Count -eq 0) {
+            $raw += [PSCustomObject]@{
+                TaskName    = "No scheduled tasks returned"
+                TaskPath    = ""
+                State       = "ReadError"
+                Enabled     = $false
+                Author      = ""
+                Description = "Task Scheduler returned no tasks. Check COM access, permissions, and the Task Scheduler service."
+                FullName    = ""
+            }
         }
     }
     catch {
-        $tasks = @()
+        $raw = @()
     }
 }
 
-foreach ($task in @($tasks)) {
-    $id = ConvertTo-WmtScheduledTaskIdentity -TaskName $task.TaskName -TaskPath $task.TaskPath
+# Project the raw rows into the display shape the grids expect (Enabled as
+# Yes/No), keeping placeholder rows explicit so telemetry tasks stay listed
+# even when they are missing or unreadable.
+foreach ($task in @($raw)) {
+    $state = [string]$task.State
+    $enabledText = "-"
+    if ($state -ne "NotFound" -and $state -ne "ReadError") {
+        if ($task.Enabled -is [bool]) {
+            $enabledText = if ($task.Enabled) { "Yes" } else { "No" }
+        }
+        elseif ($state -eq "Disabled") { $enabledText = "No" }
+        else { $enabledText = "Yes" }
+    }
     [PSCustomObject]@{
-        TaskName    = [string]$id.TaskName
-        TaskPath    = [string]$id.TaskPath
-        State       = [string]$task.State
-        Enabled     = if ([string]$task.State -eq "Disabled") { "No" } else { "Yes" }
+        TaskName    = [string]$task.TaskName
+        TaskPath    = [string]$task.TaskPath
+        State       = $state
+        Enabled     = $enabledText
         Author      = [string]$task.Author
         Description = [string]$task.Description
-        FullName    = [string]$id.FullName
+        FullName    = [string]$task.FullName
     }
 }
 }
@@ -3121,14 +3417,42 @@ param(
 )
 
 $id = ConvertTo-WmtScheduledTaskIdentity -FullName $FullName -TaskName $TaskName -TaskPath $TaskPath
+if ([string]::IsNullOrWhiteSpace($id.TaskName)) {
+    return [PSCustomObject]@{ Success = $false; Task = $id.FullName; Message = "Task name is missing." }
+}
+
 try {
-    $task = Get-WmtScheduledTaskByIdentity -TaskName $id.TaskName -TaskPath $id.TaskPath
-    if (-not $task) { throw "Task not found: $($id.FullName)" }
+    $service = New-WmtTaskSchedulerService
+    if (-not $service) { throw "The Task Scheduler service is unavailable." }
+
+    $task = $null
+    $openError = ""
+    # ITaskService has no GetTask member: open the task's folder, then fetch
+    # the task by name (the same two-step the device-health probe uses).
+    try {
+        # Same contract as the row lookup: GetFolder must not receive a
+        # trailing backslash, so strip the display-form TaskPath here too.
+        $folderPath = ([string]$id.TaskPath).TrimEnd("\")
+        if ([string]::IsNullOrWhiteSpace($folderPath)) { $folderPath = "\" }
+        $folder = $service.GetFolder($folderPath)
+        $task = $folder.GetTask([string]$id.TaskName)
+    } catch { $openError = [string]$_.Exception.Message }
+    if (-not $task) {
+        if (-not [string]::IsNullOrWhiteSpace($openError)) { throw "Could not open task $($id.FullName): $openError" }
+        throw "Task not found: $($id.FullName)"
+    }
 
     switch ($Action) {
-        "Enable" { Enable-ScheduledTask -InputObject $task -ErrorAction Stop | Out-Null }
-        "Disable" { Disable-ScheduledTask -InputObject $task -ErrorAction Stop | Out-Null }
-        "Delete" { Unregister-ScheduledTask -InputObject $task -Confirm:$false -ErrorAction Stop | Out-Null }
+        # Flipping IRegisteredTask.Enabled persists immediately - the same
+        # switch the schtasks /Change command flips - without any CIM layer.
+        "Enable" { $task.Enabled = $true }
+        "Disable" { $task.Enabled = $false }
+        "Delete" {
+            $folderPath = ([string]$id.TaskPath).TrimEnd("\")
+            if ([string]::IsNullOrWhiteSpace($folderPath)) { $folderPath = "\" }
+            $folder = $service.GetFolder($folderPath)
+            $folder.DeleteTask([string]$id.TaskName, 0)
+        }
     }
 
     [PSCustomObject]@{ Success = $true; Task = $id.FullName; Message = "$Action succeeded." }
@@ -3142,8 +3466,25 @@ function Show-WmtScheduledTasksDialog {
 param(
     [string]$Title = "Scheduled Tasks",
     [string[]]$FullPaths = @(),
-    [string[]]$TaskPaths = @()
+    [string[]]$TaskPaths = @(),
+    [string[]]$TelemetryFolders = @()
 )
+
+# Guard for the one caller contract this dialog has: show the live state
+# of the exact tasks the two telemetry buttons toggle. The View Tasks
+# button already passes that list ($script:TelemetryTasks, nine paths);
+# if a future caller or a scope surprise ever reaches the dialog with no
+# paths at all, fall back to the canonical telemetry list so the grid can
+# never open empty.
+if (@($FullPaths).Count -eq 0 -and @($TaskPaths).Count -eq 0 -and $script:TelemetryTasks) {
+    $FullPaths = @($script:TelemetryTasks)
+}
+if (@($TelemetryFolders).Count -eq 0 -and $script:WmtTelemetryTaskFolders) {
+    # No folders passed: default to the live all-telemetry enumeration.
+    $TelemetryFolders = @($script:WmtTelemetryTaskFolders)
+}
+$enumerateNote = if (@($TelemetryFolders).Count -gt 0) { " + live enumeration of $(@($TelemetryFolders).Count) telemetry folder(s)" } else { "" }
+Write-GuiLog "[Scheduled Tasks] Dialog '$Title' opened with $(@($FullPaths).Count) path(s)$enumerateNote."
 
 $content = @'
 <Grid Margin="16">
@@ -3155,6 +3496,7 @@ $content = @'
     <DataGrid Name="dgTasks" IsReadOnly="True" SelectionMode="Extended" CanUserAddRows="False" CanUserDeleteRows="False" AlternationCount="2"/>
     <TextBlock Name="lblStatus" Grid.Row="1" Foreground="{DynamicResource TextSecondary}" Margin="0,10,0,0"/>
     <WrapPanel Grid.Row="2" HorizontalAlignment="Right" Margin="0,12,0,0">
+        <Button Name="btnOpenScheduler" Content="Open Task Scheduler" MinWidth="128" Background="{DynamicResource BgElevated}" Foreground="{DynamicResource TextPrimary}" Margin="0,0,8,8"/>
         <Button Name="btnRefresh" Content="Refresh" MinWidth="92" Background="{DynamicResource Accent}" Foreground="{DynamicResource AccentText}" Margin="0,0,8,8"/>
         <Button Name="btnEnable" Content="Enable" MinWidth="92" Background="{DynamicResource Success}" Foreground="{DynamicResource SuccessText}" Margin="0,0,8,8"/>
         <Button Name="btnDisable" Content="Disable" MinWidth="92" Background="{DynamicResource Warning}" Foreground="{DynamicResource WarningText}" Margin="0,0,8,8"/>
@@ -3165,42 +3507,322 @@ $content = @'
 $dialog = New-WmtWindowFromXaml -Title $Title -ContentXaml $content -Width 960 -Height 560 -MinWidth 760 -MinHeight 420
 $dg = $dialog.FindName("dgTasks")
 $lblStatus = $dialog.FindName("lblStatus")
+$btnOpenScheduler = $dialog.FindName("btnOpenScheduler")
 $btnRefresh = $dialog.FindName("btnRefresh")
 $btnEnable = $dialog.FindName("btnEnable")
 $btnDisable = $dialog.FindName("btnDisable")
 $btnClose = $dialog.FindName("btnClose")
 
-$state = @{ Table = $null }
-$load = {
-    $rows = @(Get-WmtScheduledTaskRows -FullPaths $FullPaths -TaskPaths $TaskPaths)
-    $table = New-WmtDataTable -Columns @("TaskName", "TaskPath", "State", "Enabled", "Author", "Description", "FullName") -Rows $rows
-    $state.Table = $table
-    $dg.ItemsSource = $table.DefaultView
-    Set-WmtDataGridColumns -DataGrid $dg -Columns @("TaskName", "TaskPath", "State", "Enabled", "Author", "Description", "FullName") -Widths @{ TaskName = "*"; TaskPath = 260; State = 100; Enabled = 80; Author = 180; Description = "2*" } -Hidden @("FullName")
-    $lblStatus.Text = if ($table.Rows.Count -gt 0) { "$($table.Rows.Count) task(s)" } else { "No scheduled tasks found. Try running WMT as administrator." }
-}.GetNewClosure()
+# Two reads of the same exact paths: the direct synchronous one first
+# (milliseconds), and - only if it comes back empty or throws - the
+# background transport (Start-WmtScheduledTaskViewQuery), which re-reads
+# the paths through the pooled-runspace mechanism the Disable/Restore
+# telemetry buttons use: the one scheduled-task transport that is
+# field-proven on every machine this tool has been reported from. Every
+# failure mode lands somewhere visible: missing or unreadable tasks
+# become explicit rows (NotFound / ReadError), and a total read failure
+# goes to the status line instead of an eternal spinner.
+Set-WmtDataGridColumns -DataGrid $dg -Columns @("TaskName", "TaskPath", "State", "Enabled", "Author", "Description", "FullName") -Widths @{ TaskName = "*"; TaskPath = 260; State = 100; Enabled = 80; Author = 180; Description = "2*" } -Hidden @("FullName")
 
-$invokeSelected = {
+$load = {
+    try {
+        Set-WmtBusyCursor -Busy
+        $lblStatus.Text = "Loading tasks..."
+        $rows = @(Get-WmtScheduledTaskRows -FullPaths $FullPaths -TaskPaths $TaskPaths -TelemetryFolders $TelemetryFolders)
+        $dg.ItemsSource = @($rows)
+        Write-GuiLog "[Scheduled Tasks] View loaded $($rows.Count) row(s)."
+        if ($rows.Count -gt 0) {
+            $lblStatus.Text = "$($rows.Count) task(s)"
+        }
+        else {
+            # A zero-row direct read should be impossible (every requested
+            # path yields at least a NotFound/ReadError row); treat it as
+            # a failed read and retry through the background transport.
+            $lblStatus.Text = "Direct read returned nothing - querying in background..."
+            Start-WmtScheduledTaskViewQuery -FullPaths @($FullPaths) -TelemetryFolders @($TelemetryFolders) -DataGrid $dg -StatusBlock $lblStatus
+        }
+    }
+    catch {
+        # The direct UI-thread read threw: retry through the transport the
+        # Disable/Restore buttons use before declaring failure.
+        Write-GuiLog "[Scheduled Tasks] Direct read failed, retrying in background: $($_.Exception.Message)"
+        try {
+            $lblStatus.Text = "Retrying in background: $($_.Exception.Message)"
+            Start-WmtScheduledTaskViewQuery -FullPaths @($FullPaths) -TelemetryFolders @($TelemetryFolders) -DataGrid $dg -StatusBlock $lblStatus
+        }
+        catch {
+            Write-GuiLog "[Scheduled Tasks] Load failed: $($_.Exception.Message)"
+            $lblStatus.Text = "Failed to load tasks: $($_.Exception.Message)"
+        }
+    }
+    finally {
+        Set-WmtBusyCursor
+    }
+}.GetNewClosure()
+$apply = {
     param([string]$Action)
     $selected = @(Get-WmtDataGridSelectedRows -DataGrid $dg)
     if ($selected.Count -eq 0) { return }
     $failures = @()
-    foreach ($row in $selected) {
-        $result = Invoke-WmtScheduledTaskAction -Action $Action -TaskName ([string]$row["TaskName"]) -TaskPath ([string]$row["TaskPath"])
-        if (-not $result.Success) { $failures += "$($result.Task): $($result.Message)" }
+    try {
+        Set-WmtBusyCursor -Busy
+        foreach ($row in $selected) {
+            $result = Invoke-WmtScheduledTaskAction -Action $Action -TaskName ([string]$row.TaskName) -TaskPath ([string]$row.TaskPath)
+            if ($result.Success) {
+                Write-GuiLog "[Scheduled Tasks] $($Action)d: $($result.Task)"
+            }
+            else {
+                $failures += "$($result.Task): $($result.Message)"
+            }
+        }
     }
+    finally {
+        Set-WmtBusyCursor
+    }
+    # Flip the task, then re-read everything from Task Scheduler: flipping
+    # IRegisteredTask.Enabled is exactly what schtasks /Change does, but the
+    # grid should show what the scheduler reports now, not what we asked it
+    # to do.
     & $load
     if ($failures.Count -gt 0) {
         Show-WmtMessageBox -Owner $dialog -Message ($failures -join "`r`n") -Title "Scheduled Tasks" -Image Warning | Out-Null
     }
 }.GetNewClosure()
 
+$btnOpenScheduler.Add_Click({
+    # The dialog lists everything itself, but one click also hands over the
+    # real Task Scheduler (taskschd.msc) for anyone who wants the native
+    # view - the same launch the Startup Manager's Scheduled Tasks tab uses.
+    try {
+        Start-Process -FilePath "taskschd.msc" -ErrorAction Stop
+        Write-GuiLog "[Scheduled Tasks] Opened Windows Task Scheduler (taskschd.msc)."
+    }
+    catch {
+        Write-GuiLog "[Scheduled Tasks] Could not open Task Scheduler: $($_.Exception.Message)"
+        Show-WmtMessageBox -Owner $dialog -Message "Could not open Task Scheduler: $($_.Exception.Message)" -Title "Scheduled Tasks" -Image Warning | Out-Null
+    }
+}.GetNewClosure())
 $btnRefresh.Add_Click({ & $load }.GetNewClosure())
-$btnEnable.Add_Click({ & $invokeSelected "Enable" }.GetNewClosure())
-$btnDisable.Add_Click({ & $invokeSelected "Disable" }.GetNewClosure())
+$btnEnable.Add_Click({ & $apply "Enable" }.GetNewClosure())
+$btnDisable.Add_Click({ & $apply "Disable" }.GetNewClosure())
 $btnClose.Add_Click({ $dialog.Close() }.GetNewClosure())
-$dialog.Add_ContentRendered({ & $load }.GetNewClosure())
+# Bind one dispatcher turn after the window has been realized. WPF DataGrid
+# can throw while measuring DataView rows during the initial layout pass.
+$dialog.Add_ContentRendered({
+    $dialog.Dispatcher.BeginInvoke(
+        [Action] { & $load },
+        [System.Windows.Threading.DispatcherPriority]::Background
+    ) | Out-Null
+}.GetNewClosure())
 $dialog.ShowDialog() | Out-Null
+}
+
+function Start-WmtScheduledTaskBatchAction {
+param(
+    [Parameter(Mandatory = $true)][ValidateSet("Enable", "Disable")][string]$Action,
+    [Parameter(Mandatory = $true)][string[]]$FullPaths,
+    [Parameter(Mandatory = $true)][string]$StartMessage,
+    [Parameter(Mandatory = $true)][string]$DoneMessage
+)
+
+# Enable/Disable for a batch of tasks (telemetry toggles) runs in a background
+# runspace through the COM engine (exact-path lookups, no CIM layer) and
+# streams its results back through a collector timer.
+if ($script:WmtTaskBatchAsync) {
+    Write-GuiLog "[Scheduled Tasks] A task action is already in progress."
+    return
+}
+
+# The background runspace cannot see this script's scope, so the helper
+# functions are handed over as text. ${function:X} yields the body only (no
+# "function NAME" wrapper), so each definition is re-wrapped here; reading the
+# live definitions keeps the copies in sync automatically.
+$taskHelpers = @(
+    "function ConvertTo-WmtScheduledTaskIdentity {",
+    ${function:ConvertTo-WmtScheduledTaskIdentity},
+    "}",
+    "function New-WmtTaskSchedulerService {",
+    ${function:New-WmtTaskSchedulerService},
+    "}",
+    "function Invoke-WmtScheduledTaskAction {",
+    ${function:Invoke-WmtScheduledTaskAction},
+    "}"
+) -join "`r`n"
+
+Write-GuiLog $StartMessage
+Set-WmtBusyCursor -Busy
+
+try {
+    $ps = New-WmtPooledPowerShell
+    [void]$ps.AddScript({
+        param($Helpers, [string]$Action, $Tasks)
+        # Dot-source the helper definitions into this runspace.
+        if ($Helpers) { . ([scriptblock]::Create($Helpers)) }
+        foreach ($task in @($Tasks)) {
+            $result = Invoke-WmtScheduledTaskAction -Action $Action -FullName $task
+            if ($result.Success) {
+                Write-Output "LOG:$($Action)d: $($result.Task)"
+            }
+            else {
+                Write-Output "LOG:Failed to $($Action.ToLower()) $($result.Task): $($result.Message)"
+            }
+        }
+    }).AddArgument($taskHelpers).AddArgument($Action).AddArgument($FullPaths)
+    $script:WmtTaskBatchPs = $ps
+    $script:WmtTaskBatchAsync = $ps.BeginInvoke()
+}
+catch {
+    Write-GuiLog "[Scheduled Tasks] Failed to start task action: $($_.Exception.Message)"
+    try { if ($script:WmtTaskBatchPs) { $script:WmtTaskBatchPs.Dispose() } } catch {}
+    $script:WmtTaskBatchPs = $null
+    $script:WmtTaskBatchAsync = $null
+    Set-WmtBusyCursor
+    return
+}
+
+$script:WmtTaskBatchTimer = New-Object System.Windows.Threading.DispatcherTimer
+$script:WmtTaskBatchTimer.Interval = [TimeSpan]::FromMilliseconds(250)
+$script:WmtTaskBatchTimer.Add_Tick({
+        if (-not $script:WmtTaskBatchTimer -or -not $script:WmtTaskBatchAsync) { return }
+        if (-not $script:WmtTaskBatchAsync.IsCompleted) { return }
+        $script:WmtTaskBatchTimer.Stop()
+        try {
+            $results = @($script:WmtTaskBatchPs.EndInvoke($script:WmtTaskBatchAsync))
+            $doneMessage = $script:WmtTaskBatchDoneMessage
+            foreach ($line in $results) {
+                if ($line -is [string] -and $line.StartsWith("LOG:")) { Write-GuiLog $line.Substring(4) }
+            }
+            Write-GuiLog $doneMessage
+        }
+        catch {
+            Write-GuiLog "[Scheduled Tasks] Task action failed: $($_.Exception.Message)"
+        }
+        finally {
+            try { if ($script:WmtTaskBatchPs) { $script:WmtTaskBatchPs.Dispose() } } catch {}
+            $script:WmtTaskBatchPs = $null
+            $script:WmtTaskBatchAsync = $null
+            $script:WmtTaskBatchDoneMessage = $null
+            try { if ($script:WmtTaskBatchTimer) { $script:WmtTaskBatchTimer.Stop() } } catch {}
+            $script:WmtTaskBatchTimer = $null
+            Set-WmtBusyCursor
+        }
+    })
+$script:WmtTaskBatchDoneMessage = $DoneMessage
+$script:WmtTaskBatchTimer.Start()
+}
+
+function Start-WmtScheduledTaskViewQuery {
+param(
+    [string[]]$FullPaths = @(),
+    [string[]]$TelemetryFolders = @(),
+    $DataGrid,
+    $StatusBlock
+)
+
+# Background fallback for the View Tasks dialog. The synchronous UI-thread
+# read normally answers in milliseconds, but if it ever returns zero rows or
+# throws, this query re-reads the same exact paths through the SAME transport
+# the Disable/Restore telemetry buttons use (pooled runspace, helper functions
+# handed over as text, 250ms collector timer): the scheduled-task path that is
+# field-proven on machines where the UI-thread read has never been confirmed.
+# Each row comes back as one compact JSON string, so no live object crosses
+# the runspace boundary.
+if (@($FullPaths).Count -eq 0 -and @($TelemetryFolders).Count -eq 0) { return }
+if (-not $DataGrid) { return }
+if ($script:WmtTaskViewAsync) { return }
+
+$taskHelpers = @(
+    "function ConvertTo-WmtScheduledTaskIdentity {",
+    ${function:ConvertTo-WmtScheduledTaskIdentity},
+    "}",
+    "function New-WmtTaskSchedulerService {",
+    ${function:New-WmtTaskSchedulerService},
+    "}",
+    "function ConvertFrom-WmtRegisteredTask {",
+    ${function:ConvertFrom-WmtRegisteredTask},
+    "}",
+    "function Get-WmtAllRegisteredTasks {",
+    ${function:Get-WmtAllRegisteredTasks},
+    "}",
+    "function Get-WmtScheduledTaskRows {",
+    ${function:Get-WmtScheduledTaskRows},
+    "}"
+) -join "`r`n"
+
+$script:WmtTaskViewGrid = $DataGrid
+$script:WmtTaskViewStatus = $StatusBlock
+
+Write-GuiLog "[Scheduled Tasks] Background view query started for $(@($FullPaths).Count) path(s), $(@($TelemetryFolders).Count) telemetry folder(s)."
+
+try {
+    $ps = New-WmtPooledPowerShell
+    [void]$ps.AddScript({
+        param($Helpers, $Tasks, $Folders)
+        # Dot-source the helper definitions into this runspace.
+        if ($Helpers) { . ([scriptblock]::Create($Helpers)) }
+        try {
+            $rows = @(Get-WmtScheduledTaskRows -FullPaths $Tasks -TelemetryFolders $Folders)
+            foreach ($row in @($rows)) {
+                Write-Output ("ROW:" + ($row | ConvertTo-Json -Compress))
+            }
+        }
+        catch {
+            Write-Output ("ERR:" + [string]$_.Exception.Message)
+        }
+    }).AddArgument($taskHelpers).AddArgument($FullPaths).AddArgument($TelemetryFolders)
+    $script:WmtTaskViewPs = $ps
+    $script:WmtTaskViewAsync = $ps.BeginInvoke()
+}
+catch {
+    Write-GuiLog "[Scheduled Tasks] Failed to start background view query: $($_.Exception.Message)"
+    try { if ($script:WmtTaskViewPs) { $script:WmtTaskViewPs.Dispose() } } catch {}
+    $script:WmtTaskViewPs = $null
+    $script:WmtTaskViewAsync = $null
+    $script:WmtTaskViewGrid = $null
+    $script:WmtTaskViewStatus = $null
+    return
+}
+
+$script:WmtTaskViewTimer = New-Object System.Windows.Threading.DispatcherTimer
+$script:WmtTaskViewTimer.Interval = [TimeSpan]::FromMilliseconds(250)
+$script:WmtTaskViewTimer.Add_Tick({
+        if (-not $script:WmtTaskViewTimer -or -not $script:WmtTaskViewAsync) { return }
+        if (-not $script:WmtTaskViewAsync.IsCompleted) { return }
+        $script:WmtTaskViewTimer.Stop()
+        try {
+            $results = @($script:WmtTaskViewPs.EndInvoke($script:WmtTaskViewAsync))
+            $rowObjects = @()
+            foreach ($line in $results) {
+                if ($line -isnot [string]) { continue }
+                if ($line.StartsWith("ROW:")) {
+                    try { $rowObjects += ($line.Substring(4) | ConvertFrom-Json) } catch {}
+                }
+                elseif ($line.StartsWith("ERR:")) {
+                    Write-GuiLog "[Scheduled Tasks] Background view query failed: $($line.Substring(4))"
+                }
+            }
+            $dg = $script:WmtTaskViewGrid
+            $lbl = $script:WmtTaskViewStatus
+            if ($dg) { $dg.ItemsSource = @($rowObjects) }
+            if ($lbl) {
+                $lbl.Text = if ($rowObjects.Count -gt 0) { "$($rowObjects.Count) task(s) (background)" } else { "No scheduled tasks found. Try running WMT as administrator." }
+            }
+            Write-GuiLog "[Scheduled Tasks] View loaded $($rowObjects.Count) row(s) via background query."
+        }
+        catch {
+            Write-GuiLog "[Scheduled Tasks] Background view result failed: $($_.Exception.Message)"
+        }
+        finally {
+            try { if ($script:WmtTaskViewPs) { $script:WmtTaskViewPs.Dispose() } } catch {}
+            $script:WmtTaskViewPs = $null
+            $script:WmtTaskViewAsync = $null
+            $script:WmtTaskViewGrid = $null
+            $script:WmtTaskViewStatus = $null
+            try { if ($script:WmtTaskViewTimer) { $script:WmtTaskViewTimer.Stop() } } catch {}
+            $script:WmtTaskViewTimer = $null
+        }
+    })
+$script:WmtTaskViewTimer.Start()
 }
 
 function Get-WmtThemeHex {
@@ -4037,6 +4659,59 @@ catch {
 }
 }
 
+function Copy-WmtLibrarySelectedRowsToClipboard {
+param([System.Windows.Controls.ListView]$ListView = $lstLibrary)
+
+# Ctrl+C support for the Your Library list: copies the selected row(s) as
+# tab-separated lines (Source, Name, ID, Installed, Latest, IsUe) that
+# paste cleanly into any editor or spreadsheet - the trailing IsUe column
+# (True/False on Epic rows) makes the UE/Fab tagging verifiable straight
+# from a paste. Falls back to the focused row
+# when nothing is selected. Set-Clipboard can lose a race with another
+# app holding the clipboard open, so the write is retried briefly.
+if (-not $ListView) { return $false }
+$selectedRows = @($ListView.SelectedItems | Where-Object { $null -ne $_ })
+if ($selectedRows.Count -eq 0 -and $ListView.SelectedItem) { $selectedRows = @($ListView.SelectedItem) }
+if ($selectedRows.Count -eq 0) {
+    Write-GuiLog "Copy skipped: no library row selected."
+    return $false
+}
+
+$columns = @("Source", "Name", "Id", "Version", "Available", "IsUe")
+$lines = [System.Collections.Generic.List[string]]::new()
+foreach ($row in $selectedRows) {
+    $cells = @()
+    foreach ($column in $columns) {
+        $value = ""
+        try {
+            $property = $row.PSObject.Properties[$column]
+            if ($property) { $value = [string]$property.Value }
+        }
+        catch {}
+        $cells += (($value -replace '\r?\n', ' ').Trim())
+    }
+    [void]$lines.Add(($cells -join "`t"))
+}
+if ($lines.Count -eq 0) { return $false }
+$text = [string]::Join([Environment]::NewLine, $lines)
+
+for ($attempt = 1; $attempt -le 5; $attempt++) {
+    try {
+        [System.Windows.Clipboard]::SetText($text)
+        Write-GuiLog "Copied $($lines.Count) library line(s) to clipboard."
+        return $true
+    }
+    catch {
+        if ($attempt -eq 5) {
+            Write-GuiLog "ERROR: Could not copy library lines: $($_.Exception.Message)"
+            return $false
+        }
+        Start-Sleep -Milliseconds 40
+    }
+}
+return $false
+}
+
 function ConvertTo-WmtProcessArgument {
 param([string]$Value)
 
@@ -4781,8 +5456,10 @@ else {
             $settings.PSObject.Properties.Remove("SavedUpdateAutoScanMinutes")
         }
     }
+    # The timer restart is deliberately left to the UI layer (toggle handler /
+    # search action), which also enforces the Background Jobs gate. Starting it
+    # here as well made the "Update auto scan ..." line appear twice in the log.
     Save-WmtSettings -Settings $settings
-    Start-WmtUpdateAutoScanTimer -ResetNextRun
     return
 }
 
@@ -11873,7 +12550,14 @@ $lblStatus.Text = "Scan complete. Scanning..."
 
 $registryRows = @(
     foreach ($item in $ScanResults) {
-        $autoSelected = Test-WmtRegistryFindingAutoSelected -Item $item
+        $confidenceText = if ($item.PSObject.Properties["Confidence"] -and -not [string]::IsNullOrWhiteSpace([string]$item.Confidence)) {
+            [string]$item.Confidence
+        }
+        else {
+            ""
+        }
+        $confidenceRank = if ($confidenceText -match "(?i)^high") { 3 } elseif ($confidenceText -match "(?i)^medium") { 2 } else { 0 }
+        $autoSelected = (Test-WmtRegistryFindingAutoSelected -Item $item) -or ($confidenceRank -ge 2)
         $fixAction = if ($item.Type -eq "ReviewOnly") { "Review" } elseif ($item.Type -eq "Key") { "Delete key" } elseif ($item.Type -eq "SetValue") { "Update value" } else { "Delete value" }
         $risk = if ($item.PSObject.Properties["Risk"] -and -not [string]::IsNullOrWhiteSpace([string]$item.Risk)) {
             [string]$item.Risk
@@ -11887,8 +12571,8 @@ $registryRows = @(
         else {
             "Low"
         }
-        $confidence = if ($item.PSObject.Properties["Confidence"] -and -not [string]::IsNullOrWhiteSpace([string]$item.Confidence)) {
-            [string]$item.Confidence
+        $confidence = if (-not [string]::IsNullOrWhiteSpace($confidenceText)) {
+            $confidenceText
         }
         elseif ($autoSelected) {
             "High"
@@ -12738,6 +13422,12 @@ foreach ($candidate in $candidates) {
     if ($seen.Add($candidate)) { [void]$paths.Add($candidate) }
 }
 
+# Keep only the first usable reg.exe (System32 on 64-bit PowerShell, Sysnative
+# from a 32-bit host). One reg.exe serves /reg:32 and /reg:64 views, so trying
+# every candidate multiplied every query/delete/verify into 3-4 process spawns
+# and made deep registry cleans dramatically slower.
+if ($paths.Count -gt 1) { $paths.RemoveRange(1, $paths.Count - 1) }
+
 return @($paths)
 }
 
@@ -13111,20 +13801,10 @@ try {
     if ($existingTargets.Count -eq 0 -and $existingRegExeTargets.Count -eq 0) { return $true }
     & $AddAttempt "existing-provider/native=$($existingTargets.Count) existing-regexe=$($existingRegExeTargets.Count)"
 
-    foreach ($target in $existingTargets) {
-        if ($target.Kind -eq "Provider") { & $UnlockProviderPath ([string]$target.Path) }
-    }
-    if ($allowNativeAclUnlock) {
-        foreach ($target in $existingTargets) {
-            if ($target.Kind -eq "Native") {
-                try {
-                    $aclChanged = Grant-WmtRegistryKeyFullControlNative -Hive $target.Hive -View $target.View -SubPath $target.SubPath
-                    & $AddAttempt "acl-native=$($target.Label):$($target.SubPath) changed=$aclChanged"
-                }
-                catch { & $AddAttempt "acl-native-exception=$($target.Label):$($target.SubPath) error=$($_.Exception.Message)" }
-            }
-        }
-    }
+    # ACL unlock is deferred to the retry paths below. Rewriting ACLs before the
+    # first delete attempt (recursively for provider paths) made every cleanup
+    # item several times slower and was unnecessary for keys that delete fine;
+    # protected keys are still unlocked on the delete/retry paths below.
 
     foreach ($target in $existingTargets) {
         if (-not (& $TestTargetExists $target)) { continue }
@@ -13175,7 +13855,12 @@ try {
         }
         catch { & $AddAttempt "delete-regexe-exception=$($regTarget.RegPath) error=$($_.Exception.Message)" }
     }
-    if ($allowNativeAclUnlock) {
+    # Only use the .reg import deletion fallback when a target still exists after
+    # the direct attempts. It used to run for every CLSID-style item and added a
+    # reg.exe import (per candidate path) to every single cleanup item.
+    $preFallbackTargets = @($deleteTargets | Where-Object { & $TestTargetExists $_ })
+    $preFallbackRegTargets = @($regExeTargets | Where-Object { Test-WmtRegExeKeyExists -RegPath $_.RegPath -View $_.View })
+    if ($allowNativeAclUnlock -and ($preFallbackTargets.Count -gt 0 -or $preFallbackRegTargets.Count -gt 0)) {
         try {
             $importResult = Invoke-WmtRegExeDeleteImportFallback -RegTargets $regExeTargets
             & $AddAttempt "delete-reg-import-fallback result=$importResult"
@@ -13265,7 +13950,8 @@ catch {}
 function Start-WmtRegistryCleanupBackground {
 param(
     [object[]]$Items,
-    [string]$BackupDirectory
+    [string]$BackupDirectory,
+    [switch]$CreateRestorePoint
 )
 
 if ($script:WmtRegistryCleanupActive) {
@@ -13381,6 +14067,7 @@ try {
     $runspace.SessionStateProxy.SetVariable("CleanupSync", $cleanupSync)
     $runspace.SessionStateProxy.SetVariable("CleanupItems", $selectedItems)
     $runspace.SessionStateProxy.SetVariable("CleanupBackupDirectory", $BackupDirectory)
+    $runspace.SessionStateProxy.SetVariable("CleanupRestorePoint", [bool]$CreateRestorePoint)
 
     $workerScript = {
         Import-Module Microsoft.PowerShell.Management
@@ -13393,6 +14080,17 @@ try {
         }
 
         try {
+            if ($CleanupRestorePoint) {
+                $CleanupSync.Status = "Creating system restore point (this can take a minute)..."
+                Add-WmtCleanupWorkerLog "Creating system restore point before cleanup..."
+                try {
+                    Checkpoint-Computer -Description "WMT DeepClean" -RestorePointType "MODIFY_SETTINGS" -ErrorAction Stop
+                    Add-WmtCleanupWorkerLog "Restore Point created."
+                }
+                catch {
+                    Add-WmtCleanupWorkerLog "Restore Point failed (Disabled?). Continuing..."
+                }
+            }
             $itemsToClean = @($CleanupItems | Where-Object { $null -ne $_ -and -not [string]::IsNullOrWhiteSpace([string]$_.RegPath) })
             if (-not (Test-Path -LiteralPath $CleanupBackupDirectory -PathType Container -ErrorAction SilentlyContinue)) {
                 New-Item -Path $CleanupBackupDirectory -ItemType Directory -Force | Out-Null
@@ -18669,12 +19367,12 @@ if ($Action -eq "DeepClean") {
                 # --- SAFETY PROMPT ---
                 $res = Show-SafetyDialog -Count $toDelete.Count
                 if ($res -eq "Cancel") { return }
-                if ($res -eq "Yes") {
-                    Invoke-UiCommand { try { Checkpoint-Computer -Description "WMT DeepClean" -RestorePointType "MODIFY_SETTINGS" -ErrorAction Stop; "Restore Point created." } catch { "Restore Point failed (Disabled?). Continuing..." } } "Creating Restore Point..."
-                }
+                # The restore point is now created inside the background cleanup
+                # worker: running Checkpoint-Computer on the UI thread (via
+                # Invoke-UiCommand) froze the entire main window for its duration.
 
                 # --- EXECUTE FIX (Background Runspace) ---
-                Start-WmtRegistryCleanupBackground -Items $toDelete -BackupDirectory $bkDir
+                Start-WmtRegistryCleanupBackground -Items $toDelete -BackupDirectory $bkDir -CreateRestorePoint:($res -eq "Yes")
             }
         }.GetNewClosure())
 
@@ -22716,14 +23414,12 @@ function Show-StartupRowDetails {
                     }
                     "Scheduled Tasks" {
                         if ([string]::IsNullOrWhiteSpace($taskName)) { throw "Task name is missing." }
-                        if ([bool]$chkEnabled.IsChecked) {
-                            Enable-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction Stop | Out-Null
-                            Set-StartupCellValue $row "State" "Ready"
-                        }
-                        else {
-                            Disable-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction Stop | Out-Null
-                            Set-StartupCellValue $row "State" "Disabled"
-                        }
+                        # COM engine route: the module cmdlets fail wholesale on
+                        # broken CIM task stores, this path survives them.
+                        $taskAction = if ([bool]$chkEnabled.IsChecked) { "Enable" } else { "Disable" }
+                        $taskResult = Invoke-WmtScheduledTaskAction -Action $taskAction -TaskName $taskName -TaskPath $taskPath
+                        if (-not $taskResult.Success) { throw $taskResult.Message }
+                        Set-StartupCellValue $row "State" $(if ($taskAction -eq "Enable") { "Ready" } else { "Disabled" })
                     }
                     "Context Menu" {
                         if ([string]::IsNullOrWhiteSpace($ctxPath)) { throw "Registry key is missing." }
@@ -22907,7 +23603,9 @@ function Invoke-StartupWindowsLoad {
 }
 
 function Invoke-StartupTasksLoad {
-    $tasks = @(Get-ScheduledTask -ErrorAction SilentlyContinue | Select-Object TaskName, TaskPath, State)
+    # COM engine instead of the module cmdlets: it survives broken CIM task
+    # stores and answers in milliseconds even on slow machines.
+    $tasks = @(Get-WmtScheduledTaskRows | Select-Object TaskName, TaskPath, State)
     $table = [System.Data.DataTable]::new()
     foreach ($name in @("TaskName", "Path", "State")) { [void]$table.Columns.Add($name) }
     foreach ($task in @($tasks)) {
@@ -24276,7 +24974,7 @@ powercfg /S SCHEME_CURRENT | Out-Null
                             </Grid>
                         </Border>
                         <ListView Name="lstLibrary" Background="Transparent" Foreground="{DynamicResource TextPrimary}" BorderThickness="0"
-                                  SelectionMode="Single" ItemContainerStyle="{StaticResource FwItem}"
+                                  SelectionMode="Extended" ItemContainerStyle="{StaticResource FwItem}"
                                   VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling" ScrollViewer.CanContentScroll="True">
                             <ListView.ContextMenu>
                                 <ContextMenu Name="ctxLibrary">
@@ -24288,6 +24986,7 @@ powercfg /S SCHEME_CURRENT | Out-Null
                                     <MenuItem Name="miLibGoToDir" Header="Go to install directory" ToolTip="Open the folder where the game is installed"/>
                                     <MenuItem Name="miLibStorePage" Header="Open store page" ToolTip="Open the game's store page in your browser"/>
                                     <MenuItem Name="miLibCopyId" Header="Copy ID" ToolTip="Copy the game ID to clipboard"/>
+                                    <MenuItem Name="miLibCopyRows" Header="Copy Row Data" ToolTip="Copy the selected row(s) as tab-separated text, including the IsUe (Unreal Engine / Fab) tag"/>
                                 </ContextMenu>
                             </ListView.ContextMenu>
                             <ListView.View>
@@ -27589,6 +28288,7 @@ $miLibRepair = Get-Ctrl "miLibRepair"
 $miLibGoToDir = Get-Ctrl "miLibGoToDir"
 $miLibStorePage = Get-Ctrl "miLibStorePage"
 $miLibCopyId = Get-Ctrl "miLibCopyId"
+$miLibCopyRows = Get-Ctrl "miLibCopyRows"
 if ($lstLibrary -and $ctxLibrary) { $lstLibrary.ContextMenu = $ctxLibrary }
 $btnBackToCatalog = Get-Ctrl "btnBackToCatalog"
 $btnLibraryRefresh = Get-Ctrl "btnLibraryRefresh"
@@ -33249,7 +33949,15 @@ try {
     # Try JSON output first (much more reliable than text parsing).
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = $exe
-    $psi.Arguments = "list --json"
+    # --api-timeout 30 (a global, pre-subcommand option): the same patience for
+    # slow Epic routes as the update scan; failed fetches keep the old cache.
+    # --include-ue only while UE/Fab assets are actually shown: with the
+    # default "Fab Assets: Hidden" legendary itself omits every
+    # namespace-'ue' item, so no UE/Fab row can reach the cache even if
+    # a tag heuristic fails (this is upstream v6.6's default behavior).
+    $ueFlag = ""
+    try { if (-not (Get-WmtHideLegendaryUeAssets)) { $ueFlag = " --include-ue" } } catch {}
+    $psi.Arguments = "--api-timeout 30 list --json$ueFlag"
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError = $true
     $psi.UseShellExecute = $false
@@ -33283,6 +33991,30 @@ try {
                         try { if ($game.PSObject.Properties["version"]) { $installedVer = [string]$game.version } } catch {}
                         if ([string]::IsNullOrWhiteSpace($installedVer)) { $installedVer = $latestVer }
                     }
+                    # Tag UE/Fab assets (namespace 'ue', legendary's own skip
+                    # marker). 'namespace' is not a top-level JSON key (it is a
+                    # Python property there); it lives in asset_infos (per
+                    # platform) and in the EGS metadata blob.
+                    $legIsUe = $false
+                    try {
+                        if ($game.PSObject.Properties["asset_infos"] -and $game.asset_infos) {
+                            foreach ($aiProp in @($game.asset_infos.PSObject.Properties)) {
+                                # Object form: read .namespace directly. String form:
+                                # legendary serializes GameAsset objects via str() (json
+                                # default=str), so the value arrives as a Python repr - match
+                                # the namespace field inside that text instead.
+                                if ($aiProp.Value -is [string]) {
+                                    if ($aiProp.Value -match "(?i)namespace\s*=\s*'ue'") { $legIsUe = $true; break }
+                                }
+                                elseif (([string]$aiProp.Value.namespace) -eq 'ue') { $legIsUe = $true; break }
+                            }
+                        }
+                    } catch {}
+                    if (-not $legIsUe) {
+                        try {
+                            if ($game.PSObject.Properties["metadata"] -and $game.metadata -and $game.metadata.PSObject.Properties["namespace"] -and ([string]$game.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                        } catch {}
+                    }
                     $result.Add([PSCustomObject]@{
                             Provider         = "legendary"
                             Title            = $title
@@ -33292,6 +34024,7 @@ try {
                             IsInstalled      = $isInstalled
                             Source           = "legendary"
                             Kind             = "Library"
+                            IsUe             = $legIsUe
                         })
                 }
                 if ($result.Count -gt 0) { $parsed = $true }
@@ -33303,15 +34036,69 @@ try {
     }
 
     # Attempt 2: Text parsing fallback.
-    # Format:  * Game Title (App name: app_name, Version: version)
-    #          * Game Title (App name: app_name, Version: version, Installed: ...)
+    # Format:  * Game Title (App name: app_name | Version: version)
+    # Legendary separates the fields with a pipe, not a comma (all
+    # releases since 2020); the pattern accepts both so the app name
+    # never swallows the " | Version: ..." tail.
     if (-not $parsed) {
-        $regex = [regex]'\*+\s*(?<title>.+?)\s*\(\s*App(?:\s+name)?\s*:\s*(?<app>[^,)]+?)\s*(?:,\s*Version\s*:\s*(?<version>[^,)]+?))?\s*(?:,\s*[^)]*)?\)'
+        # The text output carries no UE/Fab marker, so tag each row from
+        # legendary's own side data (assets.json namespace set plus the
+        # per-game metadata files) and the name heuristics - the same chain
+        # the JSON path and the library scan worker use.
+        $ueAppNames = @{}
+        $ueAssetsFiles = @()
+        try { if ($env:LEGENDARY_CONFIG_PATH) { $ueAssetsFiles += (Join-Path $env:LEGENDARY_CONFIG_PATH "assets.json") } } catch {}
+        try { if ($env:XDG_CONFIG_HOME) { $ueAssetsFiles += (Join-Path $env:XDG_CONFIG_HOME "legendary\assets.json") } } catch {}
+        try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".config\legendary\assets.json") } } catch {}
+        try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".legendary\assets.json") } } catch {}
+        try { if ($env:APPDATA) { $ueAssetsFiles += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\assets.json") } } catch {}
+        foreach ($ueAssetsFile in $ueAssetsFiles) {
+            if (-not (Test-Path -LiteralPath $ueAssetsFile -PathType Leaf)) { continue }
+            try {
+                $assetsJson = [System.IO.File]::ReadAllText($ueAssetsFile) | ConvertFrom-Json -ErrorAction Stop
+                foreach ($platformProp in @($assetsJson.PSObject.Properties)) {
+                    $uePlatformAssets = @()
+                    if ($platformProp.Value -is [System.Collections.IEnumerable] -and $platformProp.Value -isnot [string] -and $platformProp.Value -isnot [System.Management.Automation.PSCustomObject]) {
+                        $uePlatformAssets = @($platformProp.Value)
+                    }
+                    elseif ($platformProp.Value -and $platformProp.Value.PSObject) {
+                        $uePlatformAssets = @($platformProp.Value.PSObject.Properties | ForEach-Object { $_.Value })
+                    }
+                    foreach ($asset in @($uePlatformAssets)) {
+                        if (([string]$asset.namespace) -eq 'ue') {
+                            $ueKey = ([string]$asset.app_name).Trim().ToLowerInvariant()
+                            if ($ueKey) { $ueAppNames[$ueKey] = $true }
+                        }
+                    }
+                }
+            }
+            catch {}
+        }
+        $ueMetaRoots = @()
+        try { if ($env:LEGENDARY_CONFIG_PATH) { $ueMetaRoots += (Join-Path $env:LEGENDARY_CONFIG_PATH "metadata") } } catch {}
+        try { if ($env:XDG_CONFIG_HOME) { $ueMetaRoots += (Join-Path $env:XDG_CONFIG_HOME "legendary\metadata") } } catch {}
+        try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".config\legendary\metadata") } } catch {}
+        try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".legendary\metadata") } } catch {}
+        try { if ($env:APPDATA) { $ueMetaRoots += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\metadata") } } catch {}
+        $regex = [regex]'\*+\s*(?<title>.+?)\s*\(\s*App(?:\s+name)?\s*:\s*(?<app>[^,|)]+?)\s*(?:[,|]\s*Version\s*:\s*(?<version>[^,|)]+?))?\s*(?:[,|]\s*[^)]*)?\)'
         foreach ($match in $regex.Matches($stdout)) {
             $title = $match.Groups["title"].Value.Trim()
             $app = $match.Groups["app"].Value.Trim()
             $ver = if ($match.Groups["version"].Success) { $match.Groups["version"].Value.Trim() } else { "" }
             if ([string]::IsNullOrWhiteSpace($title)) { continue }
+            $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$')
+            if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
+                foreach ($ueMetaRoot in $ueMetaRoots) {
+                    $ueMetaCandidate = Join-Path $ueMetaRoot "$app.json"
+                    if (-not (Test-Path -LiteralPath $ueMetaCandidate -PathType Leaf)) { continue }
+                    try {
+                        $ueMetaJson = [System.IO.File]::ReadAllText($ueMetaCandidate) | ConvertFrom-Json -ErrorAction Stop
+                        if ($ueMetaJson -and $ueMetaJson.metadata -and $ueMetaJson.metadata.PSObject.Properties["namespace"] -and ([string]$ueMetaJson.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                    }
+                    catch {}
+                    break
+                }
+            }
             $result.Add([PSCustomObject]@{
                     Provider = "legendary"
                     Title    = $title
@@ -33319,6 +34106,7 @@ try {
                     Version  = $ver
                     Source   = "legendary"
                     Kind     = "Library"
+                    IsUe     = $legIsUe
                 })
         }
     }
@@ -34548,33 +35336,53 @@ if (-not (Test-Path -LiteralPath $legendaryDir)) {
 $firstInstall = -not (Test-Path -LiteralPath $legendaryExe -PathType Leaf)
 $downloadUrl = $fallbackUrl
 $releaseName = "latest"
+$releaseResolved = $false
+for ($releaseAttempt = 1; $releaseAttempt -le 3 -and -not $releaseResolved; $releaseAttempt++) {
 try {
-Write-Host "Checking latest Legendary release..."
-$release = Invoke-RestMethod -Uri $latestApi -Headers $headers -UseBasicParsing -ErrorAction Stop
+Write-Host "Checking latest Legendary release... (attempt $releaseAttempt of 3)"
+$release = Invoke-RestMethod -Uri $latestApi -Headers $headers -UseBasicParsing -TimeoutSec 30 -ErrorAction Stop
 if ($release -and $release.tag_name) { $releaseName = [string]$release.tag_name }
 $asset = @($release.assets | Where-Object { ([string]$_.name) -ieq "legendary.exe" } | Select-Object -First 1)
 if ($asset -and $asset.browser_download_url) {
     $downloadUrl = [string]$asset.browser_download_url
 }
+$releaseResolved = $true
 }
 catch {
-Write-Warning "Could not query GitHub latest release API: $($_.Exception.Message)"
+Write-Warning "Could not query GitHub latest release API (attempt $releaseAttempt of 3): $($_.Exception.Message)"
+if ($releaseAttempt -lt 3) { Start-Sleep -Seconds (5 * $releaseAttempt) }
+}
+}
+if (-not $releaseResolved) {
 Write-Host "Falling back to GitHub's latest/download redirect."
 }
 
 $tmpPath = Join-Path $legendaryDir ("legendary.exe.{0}.download" -f ([Guid]::NewGuid().ToString("N")))
+$downloaded = $false
 try {
-Write-Host "Downloading Legendary $releaseName..."
-Write-Host $downloadUrl
-Invoke-WebRequest -Uri $downloadUrl -Headers $headers -UseBasicParsing -OutFile $tmpPath -ErrorAction Stop
+for ($downloadAttempt = 1; $downloadAttempt -le 3 -and -not $downloaded; $downloadAttempt++) {
+    Write-Host "Downloading Legendary $releaseName... (attempt $downloadAttempt of 3)"
+    Write-Host $downloadUrl
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -Headers $headers -UseBasicParsing -OutFile $tmpPath -TimeoutSec 180 -ErrorAction Stop
 
-$download = Get-Item -LiteralPath $tmpPath -ErrorAction Stop
-if ($download.Length -lt 1MB) {
-    throw "Downloaded file is unexpectedly small ($($download.Length) bytes)."
+        $download = Get-Item -LiteralPath $tmpPath -ErrorAction Stop
+        if ($download.Length -lt 1MB) {
+            throw "Downloaded file is unexpectedly small ($($download.Length) bytes)."
+        }
+
+        Move-Item -LiteralPath $tmpPath -Destination $legendaryExe -Force
+        try { Unblock-File -LiteralPath $legendaryExe -ErrorAction SilentlyContinue } catch {}
+        $downloaded = $true
+    }
+    catch {
+        Write-Warning "Legendary download failed (attempt $downloadAttempt of 3): $($_.Exception.Message)"
+        if (Test-Path -LiteralPath $tmpPath) {
+            Remove-Item -LiteralPath $tmpPath -Force -ErrorAction SilentlyContinue
+        }
+        if ($downloadAttempt -lt 3) { Start-Sleep -Seconds (5 * $downloadAttempt) }
+    }
 }
-
-Move-Item -LiteralPath $tmpPath -Destination $legendaryExe -Force
-try { Unblock-File -LiteralPath $legendaryExe -ErrorAction SilentlyContinue } catch {}
 }
 finally {
 if (Test-Path -LiteralPath $tmpPath) {
@@ -34582,11 +35390,21 @@ if (Test-Path -LiteralPath $tmpPath) {
 }
 }
 
+if (-not $downloaded -and $firstInstall) {
+throw "Legendary could not be downloaded after 3 attempts. Check the network connection and run the repair again."
+}
+
 if (-not (Test-Path -LiteralPath $legendaryExe -PathType Leaf)) {
 throw "Legendary executable was not saved to $legendaryExe."
 }
 
+if ($downloaded) {
 Write-Host "Legendary saved to:"
+}
+else {
+Write-Warning "Download failed - keeping the existing Legendary executable."
+Write-Host "Legendary kept at:"
+}
 Write-Host $legendaryExe
 & $legendaryExe --version
 
@@ -35816,6 +36634,7 @@ $script:WmtPeriodicMemoryTrimTimer.Add_Tick({
         if ($script:ScanTimer -and $script:ScanTimer.IsEnabled) { $scanBusy = $true }
         if ($script:WmtLibraryScanTimer -and $script:WmtLibraryScanTimer.IsEnabled) { $scanBusy = $true }
         if ($script:WmtLibraryCacheRunspace) { $scanBusy = $true }
+        if ($script:WmtRegistryCleanupActive -or ($script:WmtRegistryCleanupTimer -and $script:WmtRegistryCleanupTimer.IsEnabled)) { $scanBusy = $true }
         if (-not $scanBusy) {
             # Release parsed cleaner rules (re-parsed on next cleaner use)
             if ($script:CleanerMlRulesMemoryCache) { $script:CleanerMlRulesMemoryCache = $null }
@@ -37315,7 +38134,11 @@ $btnWingetScan.Add_Click({
 
                     $pInfo = New-Object System.Diagnostics.ProcessStartInfo
                     $pInfo.FileName = $legendaryCommand
-                    $pInfo.Arguments = "list-installed --check-updates --csv --show-dirs"
+                    # --api-timeout is a global (pre-subcommand) option; 30s instead of
+                    # legendary's 10s default gives slow-but-alive Epic routes time to
+                    # answer. Builds older than 0.20.27 reject it, which the retry loop
+                    # below detects and retries without the flag.
+                    $pInfo.Arguments = "--api-timeout 30 list-installed --check-updates --csv --show-dirs"
                     $pInfo.RedirectStandardOutput = $true
                     $pInfo.RedirectStandardError = $true
                     $pInfo.UseShellExecute = $false
@@ -37324,13 +38147,19 @@ $btnWingetScan.Add_Click({
                     $pInfo.StandardErrorEncoding = [System.Text.UTF8Encoding]::new($false)
 
                     # Epic endpoints intermittently fail with transient read timeouts
-                    # (legendary's HTTP client uses a 10s read timeout). Retry once on
-                    # network-class failures so a momentary blip does not kill the scan.
+                    # (legendary's HTTP client defaults to a 10s read timeout; raised to
+                    # 30s above). Retry once on network-class failures; if Epic stays
+                    # unreachable, fall back to legendary's local database below so the
+                    # installed Epic games still load.
                     $out = ""
                     $err = ""
                     $exitCode = 0
                     $maxAttempts = 2
                     $attempt = 0
+                    $networkFailure = $false
+                    $timedOut = $false
+                    $apiTimeoutStripped = $false
+                    $offlineMode = $false
                     while ($true) {
                         $attempt++
                         $p = [System.Diagnostics.Process]::Start($pInfo)
@@ -37340,7 +38169,8 @@ $btnWingetScan.Add_Click({
                             Write-Output "LOG:Legendary scan timed out after 90 seconds."
                             try { $p.Kill() } catch {}
                             try { [void]$p.WaitForExit(2000) } catch {}
-                            return
+                            $timedOut = $true
+                            break
                         }
 
                         $out = $outTask.GetAwaiter().GetResult()
@@ -37349,6 +38179,15 @@ $btnWingetScan.Add_Click({
 
                         # Success = clean exit with a CSV payload
                         if ($exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($out)) { break }
+
+                        # A legendary build older than 0.20.27 rejects --api-timeout
+                        # (argparse exit code 2); retry the same attempt without it.
+                        if (-not $apiTimeoutStripped -and $exitCode -eq 2 -and (([string]$err) -match '(?i)unrecognized arguments[^\r\n]*--api-timeout')) {
+                            $apiTimeoutStripped = $true
+                            $pInfo.Arguments = "list-installed --check-updates --csv --show-dirs"
+                            $attempt--
+                            continue
+                        }
 
                         $networkFailure = (([string]$err) -match '(?i)ReadTimeout|Read timed out|socket\.timeout|ConnectTimeout|ConnectionError|Connection reset|Connection aborted|NewConnectionError|MaxRetryError|HTTPSConnectionPool|getaddrinfo failed|Temporary failure in name resolution|timed out')
                         if ($networkFailure -and $attempt -lt $maxAttempts) {
@@ -37362,9 +38201,49 @@ $btnWingetScan.Add_Click({
                     if ($exitCode -ne 0) {
                         Write-Output "LOG:Legendary scan exited with code $exitCode."
                         if (-not [string]::IsNullOrWhiteSpace($err)) {
-                            foreach ($errLine in ($err -split "`r?`n")) {
-                                if (-not [string]::IsNullOrWhiteSpace($errLine)) { Write-Output "LOG:Legendary: $errLine" }
+                            # Python tracebacks are dozens of stack frames; keep the GUI
+                            # log readable by showing the first few and the last lines.
+                            $errLines = @(($err -split "`r?`n") | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                            for ($i = 0; $i -lt $errLines.Count; $i++) {
+                                if ($i -lt 4 -or $i -ge ($errLines.Count - 2)) {
+                                    Write-Output "LOG:Legendary: $($errLines[$i])"
+                                }
                             }
+                            if ($errLines.Count -gt 6) {
+                                Write-Output "LOG:Legendary: ... ($($errLines.Count - 6) additional stderr lines suppressed)"
+                            }
+                        }
+                    }
+
+                    # OFFLINE FALLBACK: when Epic is unreachable, list-installed WITHOUT
+                    # --check-updates reads the local install database plus the
+                    # last-synced asset versions (legendary's assets.json) with no
+                    # network access - the Epic games still load, with update info
+                    # from the last successful Epic sync.
+                    if ([string]::IsNullOrWhiteSpace($out) -and ($networkFailure -or $timedOut)) {
+                        Write-Output "LOG:Legendary could not reach Epic servers - loading installed Epic games from the local database (offline)..."
+                        try {
+                            $pInfo.Arguments = ([string]$pInfo.Arguments).Replace(" --check-updates", "")
+                            $p = [System.Diagnostics.Process]::Start($pInfo)
+                            $outTask = $p.StandardOutput.ReadToEndAsync()
+                            $errTask = $p.StandardError.ReadToEndAsync()
+                            if ($p.WaitForExit(60000)) {
+                                $out = $outTask.GetAwaiter().GetResult()
+                                $exitCode = $p.ExitCode
+                            }
+                            else {
+                                try { $p.Kill() } catch {}
+                                try { [void]$p.WaitForExit(2000) } catch {}
+                            }
+                        }
+                        catch {
+                            Write-Output "LOG:Legendary offline fallback failed: $($_.Exception.Message)"
+                        }
+                        if (-not [string]::IsNullOrWhiteSpace($out)) {
+                            $offlineMode = $true
+                        }
+                        else {
+                            Write-Output "LOG:Legendary offline fallback returned no data (no Epic games cached locally yet)."
                         }
                     }
 
@@ -37424,11 +38303,12 @@ $btnWingetScan.Add_Click({
                         }
                     }
 
+                    $offlineTag = if ($offlineMode) { " (offline - last synced Epic data)" } else { "" }
                     if ($pendingCount -eq 0) {
-                        Write-Output "LOG:Legendary scan found $installedCount installed Epic game(s), with no pending updates."
+                        Write-Output "LOG:Legendary scan$($offlineTag) found $installedCount installed Epic game(s), with no pending updates."
                     }
                     else {
-                        Write-Output "LOG:Legendary scan found $pendingCount pending Epic game update(s)."
+                        Write-Output "LOG:Legendary scan$($offlineTag) found $pendingCount pending Epic game update(s)."
                     }
                 }
                 catch {
@@ -38821,7 +39701,19 @@ $script:InvokeWingetSearch = {
                         if ($LegendaryExe -and (Test-Path -LiteralPath $LegendaryExe -PathType Leaf)) {
                             $psi = New-Object System.Diagnostics.ProcessStartInfo
                             $psi.FileName = $LegendaryExe
-                            $psi.Arguments = "list --json"
+                            # --include-ue only while UE/Fab assets are shown;
+                            # this runspace cannot call the settings helper,
+                            # so read the persisted flag from settings.json.
+                            $ueFlag = ""
+                            try {
+                                $wmtUeSettingsFile = Join-Path (Split-Path -Parent $LegCacheFile) "settings.json"
+                                if (Test-Path -LiteralPath $wmtUeSettingsFile -PathType Leaf) {
+                                    $wmtUeSettingsJson = [System.IO.File]::ReadAllText($wmtUeSettingsFile) | ConvertFrom-Json -ErrorAction Stop
+                                    if ($wmtUeSettingsJson.PSObject.Properties["HideLegendaryUeAssets"] -and -not [bool]$wmtUeSettingsJson.HideLegendaryUeAssets) { $ueFlag = " --include-ue" }
+                                }
+                            }
+                            catch {}
+                            $psi.Arguments = "--api-timeout 30 list --json$ueFlag"
                             $psi.RedirectStandardOutput = $true
                             $psi.RedirectStandardError = $true
                             $psi.UseShellExecute = $false
@@ -38848,7 +39740,29 @@ $script:InvokeWingetSearch = {
                                                 try { if ($game.PSObject.Properties["version"]) { $installedVer = [string]$game.version } } catch {}
                                                 if ([string]::IsNullOrWhiteSpace($installedVer)) { $installedVer = $latestVer }
                                             }
-                                            $result.Add([PSCustomObject]@{ Provider = "legendary"; Title = $title; Id = [string]$game.app_name; Version = $latestVer; InstalledVersion = $installedVer; IsInstalled = $isInstalled; Source = "legendary"; Kind = "Library" })
+                                            # Tag UE/Fab assets from the JSON namespace data
+                                            # (asset_infos per platform, or the metadata blob).
+                                            $legIsUe = $false
+                                            try {
+                                                if ($game.PSObject.Properties["asset_infos"] -and $game.asset_infos) {
+                                                    foreach ($aiProp in @($game.asset_infos.PSObject.Properties)) {
+                                                        # Object form: read .namespace directly. String form:
+                                                        # legendary serializes GameAsset objects via str() (json
+                                                        # default=str), so the value arrives as a Python repr - match
+                                                        # the namespace field inside that text instead.
+                                                        if ($aiProp.Value -is [string]) {
+                                                            if ($aiProp.Value -match "(?i)namespace\s*=\s*'ue'") { $legIsUe = $true; break }
+                                                        }
+                                                        elseif (([string]$aiProp.Value.namespace) -eq 'ue') { $legIsUe = $true; break }
+                                                    }
+                                                }
+                                            } catch {}
+                                            if (-not $legIsUe) {
+                                                try {
+                                                    if ($game.PSObject.Properties["metadata"] -and $game.metadata -and $game.metadata.PSObject.Properties["namespace"] -and ([string]$game.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                                                } catch {}
+                                            }
+                                            $result.Add([PSCustomObject]@{ Provider = "legendary"; Title = $title; Id = [string]$game.app_name; Version = $latestVer; InstalledVersion = $installedVer; IsInstalled = $isInstalled; Source = "legendary"; Kind = "Library"; IsUe = $legIsUe })
                                         }
                                         if ($result.Count -gt 0) { $parsed = $true }
                                     }
@@ -38856,16 +39770,85 @@ $script:InvokeWingetSearch = {
                                 catch {}
                             }
                             if (-not $parsed) {
-                                $regex = [regex]'\*+\s*(?<title>.+?)\s*\(\s*App(?:\s+name)?\s*:\s*(?<app>[^,)]+?)\s*(?:,\s*Version\s*:\s*(?<version>[^,)]+?))?\s*(?:,\s*[^)]*)?\)'
+                                # The text output carries no UE/Fab marker; tag each row
+                                # from legendary's own side data (assets.json namespace
+                                # set plus per-game metadata files) and the name
+                                # heuristics - the same chain every other cache writer
+                                # and the library scan worker use, so no row from this
+                                # path can reach the library cache without an IsUe tag.
+                                $ueAppNames = @{}
+                                $ueAssetsFiles = @()
+                                try { if ($env:LEGENDARY_CONFIG_PATH) { $ueAssetsFiles += (Join-Path $env:LEGENDARY_CONFIG_PATH "assets.json") } } catch {}
+                                try { if ($env:XDG_CONFIG_HOME) { $ueAssetsFiles += (Join-Path $env:XDG_CONFIG_HOME "legendary\assets.json") } } catch {}
+                                try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".config\legendary\assets.json") } } catch {}
+                                try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".legendary\assets.json") } } catch {}
+                                try { if ($env:APPDATA) { $ueAssetsFiles += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\assets.json") } } catch {}
+                                foreach ($ueAssetsFile in $ueAssetsFiles) {
+                                    if (-not (Test-Path -LiteralPath $ueAssetsFile -PathType Leaf)) { continue }
+                                    try {
+                                        $assetsJson = [System.IO.File]::ReadAllText($ueAssetsFile) | ConvertFrom-Json -ErrorAction Stop
+                                        foreach ($platformProp in @($assetsJson.PSObject.Properties)) {
+                                            $uePlatformAssets = @()
+                                            if ($platformProp.Value -is [System.Collections.IEnumerable] -and $platformProp.Value -isnot [string] -and $platformProp.Value -isnot [System.Management.Automation.PSCustomObject]) {
+                                                $uePlatformAssets = @($platformProp.Value)
+                                            }
+                                            elseif ($platformProp.Value -and $platformProp.Value.PSObject) {
+                                                $uePlatformAssets = @($platformProp.Value.PSObject.Properties | ForEach-Object { $_.Value })
+                                            }
+                                            foreach ($asset in @($uePlatformAssets)) {
+                                                if (([string]$asset.namespace) -eq 'ue') {
+                                                    $ueKey = ([string]$asset.app_name).Trim().ToLowerInvariant()
+                                                    if ($ueKey) { $ueAppNames[$ueKey] = $true }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    catch {}
+                                }
+                                $ueMetaRoots = @()
+                                try { if ($env:LEGENDARY_CONFIG_PATH) { $ueMetaRoots += (Join-Path $env:LEGENDARY_CONFIG_PATH "metadata") } } catch {}
+                                try { if ($env:XDG_CONFIG_HOME) { $ueMetaRoots += (Join-Path $env:XDG_CONFIG_HOME "legendary\metadata") } } catch {}
+                                try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".config\legendary\metadata") } } catch {}
+                                try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".legendary\metadata") } } catch {}
+                                try { if ($env:APPDATA) { $ueMetaRoots += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\metadata") } } catch {}
+                                $regex = [regex]'\*+\s*(?<title>.+?)\s*\(\s*App(?:\s+name)?\s*:\s*(?<app>[^,|)]+?)\s*(?:[,|]\s*Version\s*:\s*(?<version>[^,|)]+?))?\s*(?:[,|]\s*[^)]*)?\)'
                                 foreach ($match in $regex.Matches($stdout)) {
                                     $title = $match.Groups["title"].Value.Trim()
                                     if ([string]::IsNullOrWhiteSpace($title)) { continue }
+                                    $app = $match.Groups["app"].Value.Trim()
                                     $ver = if ($match.Groups["version"].Success) { $match.Groups["version"].Value.Trim() } else { "" }
-                                    $result.Add([PSCustomObject]@{ Provider = "legendary"; Title = $title; Id = $match.Groups["app"].Value.Trim(); Version = $ver; Source = "legendary"; Kind = "Library" })
+                                    $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$')
+                                    if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
+                                        foreach ($ueMetaRoot in $ueMetaRoots) {
+                                            $ueMetaCandidate = Join-Path $ueMetaRoot "$app.json"
+                                            if (-not (Test-Path -LiteralPath $ueMetaCandidate -PathType Leaf)) { continue }
+                                            try {
+                                                $ueMetaJson = [System.IO.File]::ReadAllText($ueMetaCandidate) | ConvertFrom-Json -ErrorAction Stop
+                                                if ($ueMetaJson -and $ueMetaJson.metadata -and $ueMetaJson.metadata.PSObject.Properties["namespace"] -and ([string]$ueMetaJson.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                                            }
+                                            catch {}
+                                            break
+                                        }
+                                    }
+                                    $result.Add([PSCustomObject]@{
+                                            Provider = "legendary"
+                                            Title    = $title
+                                            Id       = $app
+                                            Version  = $ver
+                                            Source   = "legendary"
+                                            Kind     = "Library"
+                                            IsUe     = $legIsUe
+                                        })
                                 }
                             }
                         }
-                        $result.ToArray() | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $LegCacheFile -Force -Encoding UTF8
+                        # Guard: never overwrite the cache with an empty result
+                        # (failed fetch racing the boot builder) - keep the last
+                        # good list, mirroring the other cache writers.
+                        $arrLeg = $result.ToArray()
+                        if ($arrLeg.Count -gt 0 -or -not (Test-Path -LiteralPath $LegCacheFile -PathType Leaf)) {
+                            $arrLeg | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $LegCacheFile -Force -Encoding UTF8
+                        }
                     }
                     catch {}
                 }
@@ -39311,7 +40294,15 @@ $script:InvokeWingetSearch = {
             # Legendary marks UE/Fab content with namespace 'ue' in its own assets.json.
             # Use it as the authoritative filter (Fab app_names are arbitrary, e.g. "PlatformFunctionsPlugin_5.4").
             $ueAppNames = @{}
+            # Legendary's config home (every release since ~2021, Windows included)
+            # is %USERPROFILE%\.config\legendary, overridable via LEGENDARY_CONFIG_PATH
+            # or XDG_CONFIG_HOME. Older builds used %USERPROFILE%\.legendary, and
+            # Heroic keeps its own copy. Probe every candidate; missing files are
+            # skipped and all hits are merged below.
             $ueAssetsFiles = @()
+            try { if ($env:LEGENDARY_CONFIG_PATH) { $ueAssetsFiles += (Join-Path $env:LEGENDARY_CONFIG_PATH "assets.json") } } catch {}
+            try { if ($env:XDG_CONFIG_HOME) { $ueAssetsFiles += (Join-Path $env:XDG_CONFIG_HOME "legendary\assets.json") } } catch {}
+            try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".config\legendary\assets.json") } } catch {}
             try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".legendary\assets.json") } } catch {}
             try { if ($env:APPDATA) { $ueAssetsFiles += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\assets.json") } } catch {}
             foreach ($ueAssetsFile in $ueAssetsFiles) {
@@ -39337,8 +40328,15 @@ $script:InvokeWingetSearch = {
                     }
                 }
                 catch {}
-                break
             }
+            # Per-game metadata files (metadata/<app_name>.json) are the most
+            # durable UE tag source; see the library scan worker.
+            $ueMetaRoots = @()
+            try { if ($env:LEGENDARY_CONFIG_PATH) { $ueMetaRoots += (Join-Path $env:LEGENDARY_CONFIG_PATH "metadata") } } catch {}
+            try { if ($env:XDG_CONFIG_HOME) { $ueMetaRoots += (Join-Path $env:XDG_CONFIG_HOME "legendary\metadata") } } catch {}
+            try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".config\legendary\metadata") } } catch {}
+            try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".legendary\metadata") } } catch {}
+            try { if ($env:APPDATA) { $ueMetaRoots += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\metadata") } } catch {}
             try {
                 if ($LegendaryCacheFile -and (Test-Path -LiteralPath $LegendaryCacheFile -PathType Leaf)) {
                     $cacheText = [System.IO.File]::ReadAllText($LegendaryCacheFile)
@@ -39349,7 +40347,24 @@ $script:InvokeWingetSearch = {
                             $title = [string]$game.Title
                             if ([string]::IsNullOrWhiteSpace($title)) { continue }
                             $legId = ([string]$game.Id).Trim()
-                            if ($hideUe -and ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$')) { continue }
+                            # Same OR chain as the library scan: cached IsUe tag first,
+                            # assets.json namespace set and name patterns as fallbacks.
+                            $legIsUe = $false
+                            try { if ($game.PSObject.Properties["IsUe"]) { $legIsUe = [bool]$game.IsUe } } catch {}
+                            if (-not $legIsUe) { $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$') }
+                            if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
+                                foreach ($ueMetaRoot in $ueMetaRoots) {
+                                    $ueMetaCandidate = Join-Path $ueMetaRoot "$legId.json"
+                                    if (-not (Test-Path -LiteralPath $ueMetaCandidate -PathType Leaf)) { continue }
+                                    try {
+                                        $ueMetaJson = [System.IO.File]::ReadAllText($ueMetaCandidate) | ConvertFrom-Json -ErrorAction Stop
+                                        if ($ueMetaJson -and $ueMetaJson.metadata -and $ueMetaJson.metadata.PSObject.Properties["namespace"] -and ([string]$ueMetaJson.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                                    }
+                                    catch {}
+                                    break
+                                }
+                            }
+                            if ($hideUe -and $legIsUe) { continue }
                             if ([string]::IsNullOrWhiteSpace($needle) -or $title.ToLowerInvariant().Contains($needle)) {
                                 # Show installed version in Version column, latest in Available.
                                 $isInst = $false
@@ -40052,6 +41067,9 @@ if (-not $Rule -or [string]::IsNullOrWhiteSpace([string]$Rule.Name)) { return }
 if ($Rule.PSObject.Properties["DetailsLoaded"] -and $Rule.DetailsLoaded) { return }
 
 $name = [string]$Rule.Name
+# The periodic memory trim releases this cache; re-create it on demand instead
+# of calling ContainsKey on $null (threw on every rule click / list rebuild).
+if (-not $script:FirewallDetailCache) { $script:FirewallDetailCache = @{} }
 if ($script:FirewallDetailCache.ContainsKey($name)) {
     Set-FirewallRuleDetails -Rule $Rule -Details $script:FirewallDetailCache[$name]
     if ($lstFw) { $lstFw.Items.Refresh() }
@@ -40115,6 +41133,7 @@ $script:FirewallDetailTimer.Add_Tick({
 
             $target = @($script:AllFw | Where-Object { $_.Name -eq $job.Name } | Select-Object -First 1)
             if ($result -and $result.Success) {
+                if (-not $script:FirewallDetailCache) { $script:FirewallDetailCache = @{} }
                 $script:FirewallDetailCache[$result.Name] = $result
                 if ($target.Count -gt 0) { Set-FirewallRuleDetails -Rule $target[0] -Details $result }
             }
@@ -40153,6 +41172,9 @@ if (-not $Rule -or [string]::IsNullOrWhiteSpace([string]$Rule.Name)) { return }
 if ($Rule.PSObject.Properties["DetailsLoaded"] -and $Rule.DetailsLoaded) { return }
 
 $name = [string]$Rule.Name
+# Self-heal after the memory trim nulls the cache (this is the selection-changed
+# entry point, so a throw here surfaced as "Exception while setting SelectedItem").
+if (-not $script:FirewallDetailCache) { $script:FirewallDetailCache = @{} }
 if ($script:FirewallDetailCache.ContainsKey($name)) {
     Set-FirewallRuleDetails -Rule $Rule -Details $script:FirewallDetailCache[$name]
     if ($lstFw) { $lstFw.Items.Refresh() }
@@ -41145,40 +42167,59 @@ $script:TelemetryTasks = @(
 "\Microsoft\Windows\Windows Error Reporting\QueueReporting"
 )
 
+# Live enumeration folders for the View Tasks dialog: every task the Task
+# Scheduler actually has under these folders is listed (merged with the
+# canonical list above), so the grid shows what THIS machine registered
+# instead of a fixed name list. The Office folder is name-filtered at read
+# time because it also holds non-telemetry servicing tasks.
+$script:WmtTelemetryTaskFolders = @(
+    "\Microsoft\Windows\Application Experience",
+    "\Microsoft\Windows\Customer Experience Improvement Program",
+    "\Microsoft\Windows\Autochk",
+    "\Microsoft\Windows\DiskDiagnostic",
+    "\Microsoft\Windows\Feedback\Siuf",
+    "\Microsoft\Windows\Windows Error Reporting",
+    "\Microsoft\Windows\NetTrace",
+    "\Microsoft\Windows\PI",
+    "\Microsoft\Windows\Device Information",
+    "\Microsoft\Office"
+)
+
 if ($btnTasksDisableTelemetry) { $btnTasksDisableTelemetry.Add_Click({
-    Invoke-UiCommand {
-        param($tasks)
-        foreach ($task in $tasks) {
-            $result = Invoke-WmtScheduledTaskAction -Action Disable -FullName $task
-            if ($result.Success) {
-                Write-GuiLog "Disabled: $task"
-            }
-            else {
-                Write-GuiLog "Failed to disable $task`: $($result.Message)"
-            }
-        }
-        Write-GuiLog "Telemetry tasks disabled!"
-    } "Disabling telemetry tasks..." -ArgumentList $script:TelemetryTasks
+    # Runs off the UI thread (the old Invoke-UiCommand version froze the whole
+    # window while every task did its own slow CIM lookup).
+    try {
+        Start-WmtScheduledTaskBatchAction -Action Disable -FullPaths $script:TelemetryTasks -StartMessage "Disabling telemetry tasks..." -DoneMessage "Telemetry tasks disabled!"
+    }
+    catch {
+        Write-WmtLastCrash -Context "Disable telemetry tasks failed" -Exception $_.Exception -ErrorRecord $_
+        Write-GuiLog "ERROR: Disable telemetry tasks failed: $($_.Exception.Message)"
+    }
 }) }
 
 if ($btnTasksRestore) { $btnTasksRestore.Add_Click({
-    Invoke-UiCommand {
-        param($tasks)
-        foreach ($task in $tasks) {
-            $result = Invoke-WmtScheduledTaskAction -Action Enable -FullName $task
-            if ($result.Success) {
-                Write-GuiLog "Enabled: $task"
-            }
-            else {
-                Write-GuiLog "Failed to enable $task`: $($result.Message)"
-            }
-        }
-        Write-GuiLog "Telemetry tasks restored!"
-    } "Restoring telemetry tasks..." -ArgumentList $script:TelemetryTasks
+    # Runs off the UI thread (the old Invoke-UiCommand version froze the whole
+    # window while every task did its own slow CIM lookup).
+    try {
+        Start-WmtScheduledTaskBatchAction -Action Enable -FullPaths $script:TelemetryTasks -StartMessage "Restoring telemetry tasks..." -DoneMessage "Telemetry tasks restored!"
+    }
+    catch {
+        Write-WmtLastCrash -Context "Restore telemetry tasks failed" -Exception $_.Exception -ErrorRecord $_
+        Write-GuiLog "ERROR: Restore telemetry tasks failed: $($_.Exception.Message)"
+    }
 }) }
 
 if ($btnTasksView) { $btnTasksView.Add_Click({
-    Show-WmtScheduledTasksDialog -Title "Telemetry Tasks" -FullPaths $script:TelemetryTasks
+    # Fully instrumented: if anything inside the dialog ever throws again, the
+    # exact PowerShell position and call stack land in last-crash.txt instead
+    # of an anonymous "Unhandled WPF dispatcher exception" line.
+    try {
+        Show-WmtScheduledTasksDialog -Title "Telemetry Tasks" -FullPaths $script:TelemetryTasks -TelemetryFolders $script:WmtTelemetryTaskFolders
+    }
+    catch {
+        Write-WmtLastCrash -Context "Telemetry tasks view failed" -Exception $_.Exception -ErrorRecord $_
+        Write-GuiLog "ERROR: Telemetry tasks view failed: $($_.Exception.Message)"
+    }
 }) }
 
 # --- WINDOWS UPDATE PRESETS ---
@@ -42167,7 +43208,15 @@ $ps = New-WmtPooledPowerShell
                 # Legendary marks UE/Fab content with namespace 'ue' in its own assets.json.
                 # Use it as the authoritative UE/Fab tag (Fab app_names are arbitrary, e.g. "PlatformFunctionsPlugin_5.4").
                 $ueAppNames = @{}
+                # Legendary's config home (every release since ~2021, Windows included)
+                # is %USERPROFILE%\.config\legendary, overridable via LEGENDARY_CONFIG_PATH
+                # or XDG_CONFIG_HOME. Older builds used %USERPROFILE%\.legendary, and
+                # Heroic keeps its own copy. Probe every candidate; missing files are
+                # skipped and all hits are merged below.
                 $ueAssetsFiles = @()
+                try { if ($env:LEGENDARY_CONFIG_PATH) { $ueAssetsFiles += (Join-Path $env:LEGENDARY_CONFIG_PATH "assets.json") } } catch {}
+                try { if ($env:XDG_CONFIG_HOME) { $ueAssetsFiles += (Join-Path $env:XDG_CONFIG_HOME "legendary\assets.json") } } catch {}
+                try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".config\legendary\assets.json") } } catch {}
                 try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".legendary\assets.json") } } catch {}
                 try { if ($env:APPDATA) { $ueAssetsFiles += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\assets.json") } } catch {}
                 foreach ($ueAssetsFile in $ueAssetsFiles) {
@@ -42193,8 +43242,17 @@ $ps = New-WmtPooledPowerShell
                         }
                     }
                     catch {}
-                    break
                 }
+                # Per-game metadata files are legendary's most durable UE tag
+                # source: every synced game gets metadata/<app_name>.json with
+                # the EGS namespace inside, even when assets.json is missing
+                # or stale.
+                $ueMetaRoots = @()
+                try { if ($env:LEGENDARY_CONFIG_PATH) { $ueMetaRoots += (Join-Path $env:LEGENDARY_CONFIG_PATH "metadata") } } catch {}
+                try { if ($env:XDG_CONFIG_HOME) { $ueMetaRoots += (Join-Path $env:XDG_CONFIG_HOME "legendary\metadata") } } catch {}
+                try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".config\legendary\metadata") } } catch {}
+                try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".legendary\metadata") } } catch {}
+                try { if ($env:APPDATA) { $ueMetaRoots += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\metadata") } } catch {}
                 foreach ($game in @($library)) {
                     $title = [string]$game.Title
                     if ([string]::IsNullOrWhiteSpace($title)) { continue }
@@ -42202,7 +43260,26 @@ $ps = New-WmtPooledPowerShell
                     # when the "Hide Unreal Engine / Fab assets" toggle is checked;
                     # update checks are never affected by the toggle.
                     $legId = ([string]$game.Id).Trim()
-                    $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$')
+                    # Prefer the IsUe tag newer WMT builds write into the cache
+                    # (from legendary's own namespace data), then fall back to the
+                    # assets.json namespace set and the name patterns so older or
+                    # stale caches still get tagged. OR semantics: a false tag from
+                    # a text-parsed cache does not veto the other sources.
+                    $legIsUe = $false
+                    try { if ($game.PSObject.Properties["IsUe"]) { $legIsUe = [bool]$game.IsUe } } catch {}
+                    if (-not $legIsUe) { $legIsUe = ($ueAppNames.ContainsKey($legId.ToLowerInvariant()) -or $legId -match '^UE[_-]?\d' -or $title -match '^\s*Unreal Engine\b' -or $legId -match '^[0-9a-fA-F]{32}$') }
+                    if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
+                        foreach ($ueMetaRoot in $ueMetaRoots) {
+                            $ueMetaCandidate = Join-Path $ueMetaRoot "$legId.json"
+                            if (-not (Test-Path -LiteralPath $ueMetaCandidate -PathType Leaf)) { continue }
+                            try {
+                                $ueMetaJson = [System.IO.File]::ReadAllText($ueMetaCandidate) | ConvertFrom-Json -ErrorAction Stop
+                                if ($ueMetaJson -and $ueMetaJson.metadata -and $ueMetaJson.metadata.PSObject.Properties["namespace"] -and ([string]$ueMetaJson.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                            }
+                            catch {}
+                            break
+                        }
+                    }
                     $isInst = $false
                     try { if ($game.PSObject.Properties["IsInstalled"]) { $isInst = [bool]$game.IsInstalled } } catch {}
                     $instVer = ""
@@ -42331,32 +43408,38 @@ $script:WmtLibraryScanTimer.Start()
 
 if ($btnShowLibrary -and $btnBackToCatalog -and $btnLibraryRefresh -and $brdCatalogList -and $brdLibraryList -and $pnlCatalogActions -and $lstLibrary) {
 $btnShowLibrary.Add_Click({
-        # Switch to library view (keep all buttons visible).
-        $brdCatalogList.Visibility = "Collapsed"
-        $brdLibraryList.Visibility = "Visible"
-        if ($btnBackToCatalog) { $btnBackToCatalog.Visibility = "Visible" }
-        if ($btnLibraryRefresh) { $btnLibraryRefresh.Visibility = "Visible" }
-        if ($btnToggleFabAssets) { $btnToggleFabAssets.Visibility = "Visible" }
+        try {
+            # Switch to library view (keep all buttons visible).
+            $brdCatalogList.Visibility = "Collapsed"
+            $brdLibraryList.Visibility = "Visible"
+            if ($btnBackToCatalog) { $btnBackToCatalog.Visibility = "Visible" }
+            if ($btnLibraryRefresh) { $btnLibraryRefresh.Visibility = "Visible" }
+            if ($btnToggleFabAssets) { $btnToggleFabAssets.Visibility = "Visible" }
 
-        # Highlight the Your Library button (AccentBtn style).
-        if ($btnShowLibrary) { $btnShowLibrary.Style = ($window.FindResource("AccentBtn") -as [System.Windows.Style]) }
+            # Highlight the Your Library button (AccentBtn style).
+            if ($btnShowLibrary) { $btnShowLibrary.Style = ($window.FindResource("AccentBtn") -as [System.Windows.Style]) }
 
-        # If we have pre-loaded results, display them instantly.
-        if ($script:WmtLibraryScanResults -and $script:WmtLibraryScanResults.Count -gt 0) {
-            $lstLibrary.Items.Clear()
-            foreach ($item in $script:WmtLibraryScanResults) {
-                if (Test-WmtFabAssetHidden $item) { continue }
-                [void]$lstLibrary.Items.Add($item)
+            # If we have pre-loaded results, display them instantly.
+            if ($script:WmtLibraryScanResults -and $script:WmtLibraryScanResults.Count -gt 0) {
+                $lstLibrary.Items.Clear()
+                foreach ($item in $script:WmtLibraryScanResults) {
+                    if (Test-WmtFabAssetHidden $item) { continue }
+                    [void]$lstLibrary.Items.Add($item)
+                }
+                if ($lblLibraryStatus) {
+                    $lblLibraryStatus.Text = "$($lstLibrary.Items.Count) game(s) in your library."
+                }
             }
-            if ($lblLibraryStatus) {
-                $lblLibraryStatus.Text = "$($lstLibrary.Items.Count) game(s) in your library."
+            elseif (-not $script:WmtLibraryScanRunspace) {
+                Start-WmtLibraryScan
+            }
+            else {
+                if ($lblLibraryStatus) { $lblLibraryStatus.Text = "Scanning libraries..." }
             }
         }
-        elseif (-not $script:WmtLibraryScanRunspace) {
-            Start-WmtLibraryScan
-        }
-        else {
-            if ($lblLibraryStatus) { $lblLibraryStatus.Text = "Scanning libraries..." }
+        catch {
+            Write-WmtLastCrash -Context "Open library view failed" -Exception $_.Exception -ErrorRecord $_
+            Write-GuiLog "ERROR: Could not open the library view: $($_.Exception.Message)"
         }
     })
 
@@ -42374,7 +43457,11 @@ $btnBackToCatalog.Add_Click({
     })
 
 $btnLibraryRefresh.Add_Click({
-        Start-WmtLibraryScan
+        try { Start-WmtLibraryScan }
+        catch {
+            Write-WmtLastCrash -Context "Library refresh failed" -Exception $_.Exception -ErrorRecord $_
+            Write-GuiLog "ERROR: Library refresh failed: $($_.Exception.Message)"
+        }
     })
 
 # --- Unreal Engine / Fab assets visibility toggle (Your Library) ---
@@ -42396,6 +43483,11 @@ $btnToggleFabAssets.Add_Click({
         # Re-apply the filter instantly; Update-WmtLibrarySearch respects any
         # active search text and the shared hide flag.
         Update-WmtLibrarySearch
+        # Rebuild the Legendary cache to match the new visibility: Hidden
+        # (default) builds it without --include-ue, Shown with UE/Fab rows.
+        # The builder's completion handler refreshes the open library view,
+        # so flipping the toggle both ways takes effect without a restart.
+        try { Start-WmtLibraryCacheBuilder } catch { Write-GuiLog "Fab assets cache refresh failed: $($_.Exception.Message)" }
         if ($lblLibraryStatus -and $brdLibraryList -and $brdLibraryList.Visibility -eq "Visible" -and $lstLibrary -and $lstLibrary.Items.Count -gt 0) {
             $lblLibraryStatus.Text = "$($lstLibrary.Items.Count) game(s) in your library."
         }
@@ -42821,9 +43913,10 @@ if ($ctxLibrary -and $lstLibrary) {
             # Show Install only if NOT installed.
             if ($miLibInstall) { $miLibInstall.Visibility = if (-not $isInstalled) { [System.Windows.Visibility]::Visible } else { [System.Windows.Visibility]::Collapsed } }
 
-            # Store page + Copy ID always visible.
+            # Store page + Copy ID + Copy Row Data always visible.
             if ($miLibStorePage) { $miLibStorePage.Visibility = [System.Windows.Visibility]::Visible }
             if ($miLibCopyId) { $miLibCopyId.Visibility = [System.Windows.Visibility]::Visible }
+            if ($miLibCopyRows) { $miLibCopyRows.Visibility = [System.Windows.Visibility]::Visible }
         }.GetNewClosure())
 
     if ($miLibLaunch) {
@@ -42905,6 +43998,38 @@ if ($ctxLibrary -and $lstLibrary) {
                 try { Set-Clipboard -Value $id; Write-GuiLog "Copied ID: $id" } catch {}
             }.GetNewClosure())
     }
+
+    if ($miLibCopyRows) {
+        $miLibCopyRows.Add_Click({
+                # Full-row copy (Source/Name/Id/Version/Available/IsUe) - the
+                # same TSV Ctrl+C produces, so the UE/Fab tag of any row can
+                # be verified straight from a paste.
+                try { [void](Copy-WmtLibrarySelectedRowsToClipboard -ListView $lstLibrary) } catch { Write-GuiLog "ERROR: Copy row data failed: $($_.Exception.Message)" }
+            }.GetNewClosure())
+    }
+}
+
+# Ctrl+C copies the selected library line(s) to the clipboard as
+# tab-separated rows (Source, Name, ID, Installed, Latest, IsUe); Ctrl+A
+# selects every row first. Mirrors the keyboard support the updates list
+# has; "Copy Row Data" in the right-click menu performs the same copy.
+if ($lstLibrary) {
+    $lstLibrary.Add_PreviewKeyDown({
+            param($s, $e)
+            try {
+                $hasControl = (([System.Windows.Input.Keyboard]::Modifiers -band [System.Windows.Input.ModifierKeys]::Control) -eq [System.Windows.Input.ModifierKeys]::Control)
+                if ($hasControl -and $e.Key -eq [System.Windows.Input.Key]::C) {
+                    if (Copy-WmtLibrarySelectedRowsToClipboard -ListView $s) { $e.Handled = $true }
+                }
+                elseif ($hasControl -and $e.Key -eq [System.Windows.Input.Key]::A) {
+                    $s.SelectAll()
+                    $e.Handled = $true
+                }
+            }
+            catch {
+                Write-GuiLog "ERROR: Library key handler failed: $($_.Exception.Message)"
+            }
+        })
 }
 
 # --- Library search box ---
@@ -43975,6 +45100,12 @@ function Update-OptionalFeaturesSynchronously {
 }
 
 $onMainWindowContentRendered = {
+# Build identity first: the title suffix and the log line answer
+# "is this the latest build?" without guessing (see the download page
+# for the line count / size / MD5 of the newest delivery).
+try {
+    Write-GuiLog "WMT GUI v$AppVersion started."
+} catch {}
 $settings = Get-WmtSettings
 
 # Restore persisted window geometry/state when valid.
@@ -44105,6 +45236,10 @@ $script:WmtLibraryCacheAsyncResult = $null
 
 function Start-WmtLibraryCacheBuilder {
 try {
+    if ($script:WmtLibraryCacheAsyncResult -and -not $script:WmtLibraryCacheAsyncResult.IsCompleted) {
+        Write-GuiLog "Library cache build already in progress."
+        return
+    }
     $settings = Get-WmtSettings
     $enabled = @($settings.EnabledProviders)
     $toggles = Get-WmtProviderToggles -Settings $settings
@@ -44265,7 +45400,19 @@ try {
                     if ($LegendaryExe -and (Test-Path -LiteralPath $LegendaryExe -PathType Leaf)) {
                         $psi = New-Object System.Diagnostics.ProcessStartInfo
                         $psi.FileName = $LegendaryExe
-                        $psi.Arguments = "list --json"
+                        # --include-ue only while UE/Fab assets are shown;
+                        # this runspace cannot call the settings helper,
+                        # so read the persisted flag from settings.json.
+                        $ueFlag = ""
+                        try {
+                            $wmtUeSettingsFile = Join-Path (Split-Path -Parent $LegCacheFile) "settings.json"
+                            if (Test-Path -LiteralPath $wmtUeSettingsFile -PathType Leaf) {
+                                $wmtUeSettingsJson = [System.IO.File]::ReadAllText($wmtUeSettingsFile) | ConvertFrom-Json -ErrorAction Stop
+                                if ($wmtUeSettingsJson.PSObject.Properties["HideLegendaryUeAssets"] -and -not [bool]$wmtUeSettingsJson.HideLegendaryUeAssets) { $ueFlag = " --include-ue" }
+                            }
+                        }
+                        catch {}
+                        $psi.Arguments = "--api-timeout 30 list --json$ueFlag"
                         $psi.RedirectStandardOutput = $true
                         $psi.RedirectStandardError = $true
                         $psi.UseShellExecute = $false
@@ -44295,6 +45442,28 @@ try {
                                             try { if ($game.PSObject.Properties["version"]) { $installedVer = [string]$game.version } } catch {}
                                             if ([string]::IsNullOrWhiteSpace($installedVer)) { $installedVer = $latestVer }
                                         }
+                                        # Tag UE/Fab assets from the JSON namespace data
+                                        # (asset_infos per platform, or the metadata blob).
+                                        $legIsUe = $false
+                                        try {
+                                            if ($game.PSObject.Properties["asset_infos"] -and $game.asset_infos) {
+                                                foreach ($aiProp in @($game.asset_infos.PSObject.Properties)) {
+                                                    # Object form: read .namespace directly. String form:
+                                                    # legendary serializes GameAsset objects via str() (json
+                                                    # default=str), so the value arrives as a Python repr - match
+                                                    # the namespace field inside that text instead.
+                                                    if ($aiProp.Value -is [string]) {
+                                                        if ($aiProp.Value -match "(?i)namespace\s*=\s*'ue'") { $legIsUe = $true; break }
+                                                    }
+                                                    elseif (([string]$aiProp.Value.namespace) -eq 'ue') { $legIsUe = $true; break }
+                                                }
+                                            }
+                                        } catch {}
+                                        if (-not $legIsUe) {
+                                            try {
+                                                if ($game.PSObject.Properties["metadata"] -and $game.metadata -and $game.metadata.PSObject.Properties["namespace"] -and ([string]$game.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                                            } catch {}
+                                        }
                                         $result.Add([PSCustomObject]@{
                                                 Provider         = "legendary"
                                                 Title            = $title
@@ -44304,6 +45473,7 @@ try {
                                                 IsInstalled      = $isInstalled
                                                 Source           = "legendary"
                                                 Kind             = "Library"
+                                                IsUe             = $legIsUe
                                             })
                                     }
                                     if ($result.Count -gt 0) { $parsed = $true }
@@ -44316,18 +45486,72 @@ try {
 
                         # Attempt 2: Text parsing fallback
                         if (-not $parsed) {
-                            $regex = [regex]'\*+\s*(?<title>.+?)\s*\(\s*App(?:\s+name)?\s*:\s*(?<app>[^,)]+?)\s*(?:,\s*Version\s*:\s*(?<version>[^,)]+?))?\s*(?:,\s*[^)]*)?\)'
+                            # The text output carries no UE/Fab marker; tag each
+                            # row from legendary's own side data (assets.json
+                            # namespace set plus per-game metadata files) and
+                            # the name heuristics, like every other site.
+                            $ueAppNames = @{}
+                            $ueAssetsFiles = @()
+                            try { if ($env:LEGENDARY_CONFIG_PATH) { $ueAssetsFiles += (Join-Path $env:LEGENDARY_CONFIG_PATH "assets.json") } } catch {}
+                            try { if ($env:XDG_CONFIG_HOME) { $ueAssetsFiles += (Join-Path $env:XDG_CONFIG_HOME "legendary\assets.json") } } catch {}
+                            try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".config\legendary\assets.json") } } catch {}
+                            try { if ($env:USERPROFILE) { $ueAssetsFiles += (Join-Path $env:USERPROFILE ".legendary\assets.json") } } catch {}
+                            try { if ($env:APPDATA) { $ueAssetsFiles += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\assets.json") } } catch {}
+                            foreach ($ueAssetsFile in $ueAssetsFiles) {
+                                if (-not (Test-Path -LiteralPath $ueAssetsFile -PathType Leaf)) { continue }
+                                try {
+                                    $assetsJson = [System.IO.File]::ReadAllText($ueAssetsFile) | ConvertFrom-Json -ErrorAction Stop
+                                    foreach ($platformProp in @($assetsJson.PSObject.Properties)) {
+                                        $uePlatformAssets = @()
+                                        if ($platformProp.Value -is [System.Collections.IEnumerable] -and $platformProp.Value -isnot [string] -and $platformProp.Value -isnot [System.Management.Automation.PSCustomObject]) {
+                                            $uePlatformAssets = @($platformProp.Value)
+                                        }
+                                        elseif ($platformProp.Value -and $platformProp.Value.PSObject) {
+                                            $uePlatformAssets = @($platformProp.Value.PSObject.Properties | ForEach-Object { $_.Value })
+                                        }
+                                        foreach ($asset in @($uePlatformAssets)) {
+                                            if (([string]$asset.namespace) -eq 'ue') {
+                                                $ueKey = ([string]$asset.app_name).Trim().ToLowerInvariant()
+                                                if ($ueKey) { $ueAppNames[$ueKey] = $true }
+                                            }
+                                        }
+                                    }
+                                }
+                                catch {}
+                            }
+                            $ueMetaRoots = @()
+                            try { if ($env:LEGENDARY_CONFIG_PATH) { $ueMetaRoots += (Join-Path $env:LEGENDARY_CONFIG_PATH "metadata") } } catch {}
+                            try { if ($env:XDG_CONFIG_HOME) { $ueMetaRoots += (Join-Path $env:XDG_CONFIG_HOME "legendary\metadata") } } catch {}
+                            try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".config\legendary\metadata") } } catch {}
+                            try { if ($env:USERPROFILE) { $ueMetaRoots += (Join-Path $env:USERPROFILE ".legendary\metadata") } } catch {}
+                            try { if ($env:APPDATA) { $ueMetaRoots += (Join-Path $env:APPDATA "heroic\legendaryConfig\legendary\metadata") } } catch {}
+                            $regex = [regex]'\*+\s*(?<title>.+?)\s*\(\s*App(?:\s+name)?\s*:\s*(?<app>[^,|)]+?)\s*(?:[,|]\s*Version\s*:\s*(?<version>[^,|)]+?))?\s*(?:[,|]\s*[^)]*)?\)'
                             foreach ($match in $regex.Matches($stdout)) {
                                 $title = $match.Groups["title"].Value.Trim()
                                 if ([string]::IsNullOrWhiteSpace($title)) { continue }
+                                $app = $match.Groups["app"].Value.Trim()
                                 $ver = if ($match.Groups["version"].Success) { $match.Groups["version"].Value.Trim() } else { "" }
+                                $legIsUe = ($ueAppNames.ContainsKey($app.ToLowerInvariant()) -or $app -match '^UE[_-]?\d' -or $title -match '^\s*(Unreal Engine|UE[_-]?\d)' -or $app -match '^[0-9a-fA-F]{32}$')
+                                if (-not $legIsUe -and $ueMetaRoots.Count -gt 0) {
+                                    foreach ($ueMetaRoot in $ueMetaRoots) {
+                                        $ueMetaCandidate = Join-Path $ueMetaRoot "$app.json"
+                                        if (-not (Test-Path -LiteralPath $ueMetaCandidate -PathType Leaf)) { continue }
+                                        try {
+                                            $ueMetaJson = [System.IO.File]::ReadAllText($ueMetaCandidate) | ConvertFrom-Json -ErrorAction Stop
+                                            if ($ueMetaJson -and $ueMetaJson.metadata -and $ueMetaJson.metadata.PSObject.Properties["namespace"] -and ([string]$ueMetaJson.metadata.namespace) -eq 'ue') { $legIsUe = $true }
+                                        }
+                                        catch {}
+                                        break
+                                    }
+                                }
                                 $result.Add([PSCustomObject]@{
                                         Provider = "legendary"
                                         Title    = $title
-                                        Id       = $match.Groups["app"].Value.Trim()
+                                        Id       = $app
                                         Version  = $ver
                                         Source   = "legendary"
                                         Kind     = "Library"
+                                        IsUe     = $legIsUe
                                     })
                             }
                         }
@@ -44666,6 +45890,14 @@ try {
             try { $script:WmtLibraryCacheRunspace.Dispose() } catch {}
             $script:WmtLibraryCacheRunspace = $null
             $script:WmtLibraryCacheAsyncResult = $null
+            # If the library view is open, refresh it from the rebuilt
+            # cache (covers the Fab-assets toggle: the rebuild flips the
+            # --include-ue flag and the open view picks the change up
+            # immediately; the boot-time build finds the view closed and
+            # skips this).
+            if ($brdLibraryList -and $brdLibraryList.Visibility -eq [System.Windows.Visibility]::Visible -and $lstLibrary) {
+                try { Start-WmtLibraryScan -Silent } catch {}
+            }
         }.GetNewClosure())
     $timer.Start()
 }
@@ -44810,7 +46042,16 @@ try {
     }
 }
 catch {}
-try { if ($script:WmtLibraryScanTimer) { $script:WmtLibraryScanTimer.Stop(); $script:WmtLibraryScanTimer = $null } } catch {}
+try { if ($script:WmtTaskBatchTimer) { $script:WmtTaskBatchTimer.Stop(); $script:WmtTaskBatchTimer = $null } } catch {}
+try {
+    if ($script:WmtTaskBatchPs) {
+        try { $script:WmtTaskBatchPs.Stop() } catch {}
+        try { $script:WmtTaskBatchPs.Dispose() } catch {}
+        $script:WmtTaskBatchPs = $null
+        $script:WmtTaskBatchAsync = $null
+    }
+}
+catch {}
 try { if ($script:WmtLibrarySearchTimer) { $script:WmtLibrarySearchTimer.Stop(); $script:WmtLibrarySearchTimer = $null } } catch {}
 try { if ($script:StatsTimer) { $script:StatsTimer.Stop(); $script:StatsTimer = $null } } catch {}
 try { if ($script:UpdateTimer) { $script:UpdateTimer.Stop(); $script:UpdateTimer = $null } } catch {}


### PR DESCRIPTION
# Patch Notes — v6.6 (PR #152)

**PR:** [6.6: Fix context menu on package updates page, performance improvements, hiding FAB assets from "your library", new driver page with full driver list, start minimized.... #152](https://github.com/ios12checker/Windows-Maintenance-Tool/pull/152)
**Author:** Chaython · **Status:** Open · **Target:** `ios12checker:main` ← `Chaython:Main`
**Scope:** 1 file changed (`WMT-GUI.ps1`) · **+4,668 / −556 lines** · **13 commits** (Sep 6 – Sep 15)

---

## 🐛 Bug Fixes

### Right-click Menu on Package Updates Page (the main bug)
- Fixed a bug where the `ContextMenuOpening` handler on the update list lacked parameter declarations (`param($s,$e)`), causing `$s` to resolve to `$null`.
- Resolved the empty-selection check error that threw on every right-click and caused WPF to silently abort the menu. Added proper parameters alongside a `@()`.
- Applied the same fix to the Firewall page and the global crash handler (`param($s,$eA)`).

### Library search re-displaying Fab assets
- Filter state moved to a single `$global` flag with a shared guard function used across all population paths. This resolves the bug where entering/exiting library search re-displayed Fab assets due to unreliable closure lookups.

### Search debounce timer
- The search debounce timer no longer nulls itself after the first tick.

### Driver Cleaner — "Clean Old Drivers" detection reworked
- **Fixed version-vs-date comparison:** duplicate ranking previously sorted by driver *date first*, so drivers shipped with an older date than their replacement (e.g. NVIDIA `nvpcf.inf` 32.0.16.1051 dated 6/2/2026 vs the newer 32.0.16.1534 dated 5/20/2026) were kept as "newest" while the active copy got filtered out — resulting in "Driver store is already clean" even when an old package existed. Ranking now prefers the in-use copy, then the **highest driver version**, and only uses the date as a tiebreak (e.g. for version-less INFs like `aispeechapoext.inf` that carry a date-only DriverVer and show as "Unknown" version).
- **Safety additions:** packages with a *higher* version than the kept copy are never removed (they may be staged for next boot), in-use packages are skipped during selection, and same-version duplicates are classified as "Duplicate copy" instead of "Older version".
- **Version parsing fixed — no more "Unknown" for drivers that have a version:** on some systems pnputil's `/enum-drivers` text output never yields a parseable `Driver Version` line, so every package showed Version "Unknown" and version-based ranking silently degraded to date-only. The cleaner now falls back to reading the `DriverVer` directive directly from the staged INF copy (`C:\Windows\INF\oemXX.inf`) — the same source of truth Driver Store Explorer (RAPR) uses. pnputil parsing was also hardened: dotted-date locales (`02.06.2026 32.0.16.1051`) no longer get mistaken for the version (last dotted group wins), and single-digit dates (`6/2/2026`) now parse. INFs that genuinely have no numeric version (e.g. `aispeechapoext.inf`) still show "Unknown" correctly.
- **Transparency:** the cleanup dialog now shows **Status** (why the package is flagged: Older version / Duplicate copy / Duplicate older store date) and **Kept** (the exact package kept, with its version and date) columns so flagged entries can be verified against their surviving twin.

### Scheduled tasks — "Open Location"
- Fixed the Open Location button opening the wrong Task Scheduler location: you can't navigate directly to a task, so "Open Task Scheduler" was moved to its own button. (Related: #158)

### Startup Manager
- Services moved to the bottom of the list instead of the details view.
- Fixed theming of the drop-down box.
- Fixed "Open Location" behavior; added "Open Registry" action.

### Explorer context menu (Take Ownership / PowerShell Here)
- Fixed inverted labels — the installed state previously showed "Add…" while clicking actually removed the entry.
- Aligned load-time detection with the HKCR merged view so machine-wide installs are correctly detected after a restart.

### Activity Log
- `ToBoolean` hardening added for the activity-log switch, alongside corrected state wording in log entries (via merged commit `d127ef4`). (Related: #149)

---

## ✨ New Features

### Drivers page — full list-view rework
- The Drivers page now lists **every third-party driver package staged in the Driver Store** in the same list style as Package Updates / Firewall: header card with live status line, colored legend (green = In Use, amber = Old, red = Unattached, gray = Inactive) and a search box; a virtualized sortable grid (Status / Class / Provider / Driver / Store File / Version / Date / Devices); and **all previous driver tools in a bottom action bar** (Generate Report, Export Drivers, Remove Ghosts, Clean Old, Restore, Auto-Drivers toggle, Metadata toggle) plus a new **Reload** button.
- **Status highlighting is live and two-phase:** rows appear immediately from a fast pnputil scan, then a background query of `Win32_PnPSignedDriver` + `Win32_PnPEntity` colors each row — **In Use** (bound to a present, working device), **Old** (superseded duplicate copy in the store — exactly what "Clean Old" removes), **Unattached** (no device is currently attached — switched-off/disconnected hardware may still need it) and **Inactive** (bound only to devices that are disabled or reporting problems). Row and cell tooltips explain each verdict and list the exact devices using the package.
- **Filter/service drivers are classified correctly:** packages that never bind to a single device — antivirus filters (ESET etc.), audio effects (Voicemod/APOs), keyboard/HSM filters (gameflt), bus drivers (Samsung/Apple USB), AMD chipset services — used to be mislabeled because no device references them. The background pass now parses each package's staged INF for `AddService` entries and checks them against Windows' registered driver services (`Win32_SystemDriver` + `Win32_Service` + the Services registry): any package whose service exists is shown **In Use** (tooltip says whether the service is running or registered/on-demand) and is treated as NOT safe to remove. "Unattached" now only appears when there is neither a device binding nor a registered service.
- **Full right-click context menu** with smart enable/disable: Driver Details (also on double-click), Open INF Location, Find Devices Using This Driver (live re-check), Copy Store File Name / Copy Driver INF Name / Copy as Table (Ctrl+C) / Copy Full Details, **Remove Driver Package** (explicit confirmation, extra warning when a package is actively in use, pnputil delete with force fallback) plus shortcuts to Clean Old Drivers, Remove Ghost Devices and Refresh. All eight columns sort via header clicks, and the search box filters every field (including device names) with debounced live updates.
- **The list is keyboard-copiable:** rows support multi-select (Ctrl+Click / Shift+Click), **Ctrl+A** selects every visible row and **Ctrl+C** copies the selection as a tab-separated table (header row + one line per driver, columns matching the list) that pastes into Excel, Google Sheets or Notepad with columns intact — also available as a context-menu item.
- **One-click web lookups** (right-click → single row): **Check on VirusTotal** opens a themed chooser window (matches the app's dark/light theme) showing the INF's SHA256 in a selectable, copyable read-only box with three options — **Search by Hash** (green; instant database lookup — a hash VirusTotal has never seen shows "No results"), **Upload Sample** (opens the virustotal.com upload page plus an Explorer window with the INF pre-selected for drag-and-drop live scanning) and **Cancel** (Esc works too); falls back to a name search when the INF can't be hashed. **Search Microsoft Update Catalog** looks up the driver's original INF name on `catalog.update.microsoft.com` — the safe, signed driver source (falls back to "Provider Class"). **Ask Gemini About This Driver** runs "what is <driver>, <provider>, version <version>" through Google's Gemini-powered AI Mode (`google.com/search?udm=50`) for an immediate answer — the Gemini web app has no URL prefill, so the question is also copied to the clipboard for pasting into gemini.google.com if you prefer.
- **Enable / Disable Device from the list (right-click):** per-device actions appear directly in the context menu under "Find Devices Using This Driver" — a running device shows **"Disable device …"** (with a confirmation warning), a disabled or problem device shows **"Enable device …"** (labeled "disabled in Device Manager" when applicable), plus "No devices bound to this package" for unattached packages; the device is toggled via `pnputil /enable-device | /disable-device` (admin), both idempotent so a wrong guess is harmless. On success the cached list updates **in place** — the row re-colors between **In Use** and **Inactive** instantly with no full recheck (pnputil exit 3010 = reboot pending → the list is left unchanged with an explicit log line). Entries rebuild on every menu open and cap at 12 devices with a pointer to the full list. (They are flat menu items rather than a WPF submenu — the app's flat menu template has no popup part, so submenus under it silently never open.)
- **"Inactive" is now self-explanatory:** the header status line and the colored legend read **Inactive (disabled in Device Manager)** — the status means the package is only bound to present devices that are disabled in Device Manager or reporting a problem (ConfigManagerErrorCode ≠ 0), and the row tooltip spells that out, lists each device with its precise state ("disabled in Device Manager" vs "problem") and points at the new toggle. The background device scan now records each device's ConfigManagerErrorCode so the wording can be exact.
- The status line totals everything at a glance (e.g. "112 driver package(s) · 41 In Use · 3 Old · 12 Unattached · 2 Inactive (disabled in Device Manager)"), and the Drivers tab lazy-loads the first time you open it.
- **"Unattached" replaces the misleading "Unneeded" label:** no attached device does NOT mean safe to remove — hardware can be switched off, disabled or disconnected (a camera that is off, an iGPU idle while a laptop runs on the dGPU, antivirus features toggled off) or connect only occasionally (printers, USB gear). The row tint, legend, status line, tooltips, details and devices dialogs all use the safer term, and the tooltip spells out exactly those scenarios instead of implying the package can be deleted.
- **The loaded list is cached — removals no longer recheck everything:** re-opening the Drivers tab keeps the loaded rows instead of re-running the whole pnputil enumeration + device/service pass; removing driver packages now updates the cached list **in place** — only rows pnputil actually deleted disappear (exit 0 or 3010-reboot-required both count as success), failed rows keep their place, and statuses are recomputed instantly from the cached maps (removing the kept copy of a duplicate group un-"Olds" the survivor). Clean Old Drivers syncs its deletions into the same cached list, and Restore Drivers invalidates the cache so the newly staged packages appear. The **Reload** button and context-menu **Refresh** still force a full recheck at any time.

### "Fab Assets" hide button (redesigned)
- The Unreal Engine (UE) / Fab hide toggle is now a proper button in the bottom action bar next to **Back to Catalog / Refresh Library** (with matching icon and style), replacing the checkbox that previously occupied a row above the list.
- Button label dynamically reflects the live state (**Fab Assets: Hidden / Shown**).
- Hiding Fab assets now rebuilds the Legendary cache to remove UE assets when the user wants them hidden.

### Chocolatey manifests & community page in Package Updates
- Added Chocolatey manifest support and a Chocolatey community page to the package updates view.

### Start minimized
- Added a "Start Minimized" option alongside the improved "Start with Windows" behavior. (Related: #157)

### Library row export
- Added clipboard export support for library rows.

### Live telemetry-folder enumeration
- Scheduled-task view now enumerates telemetry folders live and shows explicit rows for missing tasks.

---

## 🔧 Improvements

### Legendary — UE/Fab handling reworked
- UE/Fab rows are now tagged (`IsUe`) when Your Library reads the cache and filtered only at display time.
- `legendary_library.json` always retains the complete list, preventing failed scans or network outages from shrinking local data (the offline "flush" rewrite was removed).
- Package Updates now scans UE/Fab apps again: the previous skip that excluded them from update checks has been removed so engine and marketplace assets receive update checks like any other Epic app.
- Improved Legendary download, authentication, and offline library scanning.
- Both `assets.json` loaders (library scan + package search) now support array-of-assets and app-name-to-asset maps. Update checks for UE assets remain fully active.

### Background Jobs & Update Scans
- **BG Jobs / Update Scans buttons restyled as proper toggles:** both now show **Blue = On / Gray = Off** (via `Update-WmtTweakToggle`, matching the Start with Windows button beside them) with the same two-line tooltip format: current state line ("Blue = active/applied" / "Gray = inactive/default") plus a "Click to switch to…" line and a state description.
- Toggling via search actions now keeps the buttons fully in sync (previously search-enabled BG Jobs left the button gray with stale text).
- Re-enabling Background Jobs (via Settings toggle or search action) now **immediately** triggers boot-time jobs: My Device stats, tweak states, optional features, AppX list, library caches, and the update auto-scan timer — instead of requiring a restart.
- My Device clears "scanning is disabled" placeholders and reloads stats instantly upon re-enabling.
- The Update Scans toggle symmetrically restarts or stops the periodic scan timer.
- BG Jobs / BG Scans messaging improvements: the disabled status is written only once, even if the timer setup runs repeatedly; when "Update Scans" is enabled, any stale disabled message is removed.

### Task management hardening
- Replaced scheduled-task CIM queries with Task Scheduler COM APIs.
- Improved scheduled-task dialog loading and avoided unstable DataGrid `DataView` binding.
- Hardened pooled runspace creation and recovery.

### Registry cleanup defaults
- Registry findings are now selected with explicit **Medium or High** confidence by default.
- Improved registry deletion fallback and 32/64-bit registry handling.

### Other workflow improvements
- Improved Winget, firewall, startup-manager, and library background workflows.
- General performance improvements.

---

## 📜 Commit Log (13 commits)

| Date | SHA | Commit Message |
|------|-----|----------------|
| Sep 6 | `724e6d3` | Fix context menu on package updates page, performance improvements, BG Jobs ON fires immediately now rather than restart, merge commit `d127ef4`, version bump, in your library add a button to hide fab assets |
| Sep 8 | `403d68e` | feat: harden task management and registry cleanup defaults — Replace scheduled-task CIM queries with Task Scheduler COM APIs; add live telemetry-folder enumeration and explicit missing-task rows; improve scheduled-task dialog loading and avoid unstable DataGrid DataView binding; harden pooled runspace creation and recovery; select registry findings with explicit Medium or High confidence by default; improve registry deletion fallback and 32/64-bit registry handling; add library-row clipboard export support; improve Legendary download, authentication, and offline library scanning; improve Winget, firewall, startup-manager, and library background workflows |
| Sep 8 | `41f2dc0` | Better fab asset hiding |
| Sep 8 | `cd66917` | Rebuilds the legendary cache to remove UE assets if user wants them hidden |
| Sep 8 | `ee0c234` | BG JOBS / BG SCANS messaging improvements: The disabled status is written only once, even if the timer setup runs repeatedly. When "Update Scans" is enabled, any stale disabled message is removed. |
| Sep 11 | `e82e9a3` | Improve start with windows, add a start minimized |
| Sep 13 | `118b552` | Fix open location for scheduled tasks, move open task scheduler to buttons as we can't navigate directly to a task |
| Sep 14 | `891f348` | Start up manager — services: Move services to bottom instead of details, fix theming of drop down box, add open registry, fix open location |
| Sep 14 | `ce06c7c` | Chocolatey Manifests / Chocolatey community page in package updates view |
| Sep 14 | `4ddbd47` | BG Jobs / Update Scans: blue-when-on toggle styling + standard tooltips matching Start with Windows |
| Sep 15 | `4e90d92` | Clean old drivers improvements — INF `DriverVer` fallback, version-first duplicate ranking, Status/Kept columns |
| Sep 15 | `291803f` | Completely remake the driver page — full driver list with per-row device counts and In Use / Old / Unattached / Inactive (disabled in Device Manager) statuses, service-driver detection, VirusTotal / Microsoft Update Catalog / Gemini lookups, Ctrl+C table copy, cached list with in-place removal |
| Sep 15 | `d5b8b30` | Enable / Disable device (Device Manager) from the driver list context menu — `pnputil` toggle, in-place row recolor, flat per-device entries |

---

## 🔗 Referenced Issues

- #149 — Fix activity log of Bg Jobs and Update Scans buttons (Closed)
- #148 — Improve Tweaks panel loading (Closed)
- #157 — Start With Windows option not clear if on + start minimized (Open)
- #158 — [BUG] Open Location button opens the wrong Task Scheduler location (Open)
